### PR TITLE
Tighten version constraints in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
   "type": "library",
   "keywords": ["laravel", "excel", "csv", "xls", "xlsx"],
   "require": {
-    "illuminate/database": "^5.5",
-    "illuminate/support": "^5.5",
+    "illuminate/database": "5.5.* || 5.6.*",
+    "illuminate/support": "5.5.* || 5.6.*",
     "box/spout": "^2.7"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8a5356ec0fc60ffda8bd25e816b5a1e",
+    "content-hash": "559884a1f47c9fe371a7595604a419ac",
     "packages": [
         {
             "name": "box/spout",


### PR DESCRIPTION
[`^5.5`](https://semver.mwl.be/#?package=laravel%2Fframework&version=%5E5.5&minimum-stability=stable) means that it'll accept anything above `5.5`, but not `6.0`. Because [Laravel doesn't follow](https://medium.com/@vinkla/laravel-packages-and-semantic-versioning-f62dc5accee5) [semver](https://semver.org/), it's recommended to specify the exact versions your package will work on. In this case, [`5.5.*` and `5.6.*`](https://semver.mwl.be/#?package=laravel%2Fframework&version=5.5.*%20%7C%7C%205.6.*&minimum-stability=stable) will be fine.

I've also updated the `composer.lock`'s `hash` key (with `composer update --hash`), but generally, `composer.lock` files aren't required in packages. I'll submit a second PR to remove it entirely, so you can decide whether to keep it or not. 

**Note:** When Laravel 5.7 is released, this file will need to be updated to include `|| 5.7.*` 🙂 