### PR TITLE
Refactoring & Return nested Sheet Collection instead of flat Rows

### DIFF
--- a/src/Importable.php
+++ b/src/Importable.php
@@ -58,7 +58,7 @@ trait Importable
                 }
                 return $this->sheet_number == $key;
             })
-            ->map(function(&$sheet, $key) use ($rowCallback)
+            ->map(function($sheet, $key) use ($rowCallback)
             {
                 $headers = [];
                 $collection = [];
@@ -89,7 +89,10 @@ trait Importable
                     }
                 }
 
-                return collect($collection);
+                $sheet->sheetName = $sheet->getName();
+                $sheet->sheetData = collect($collection);
+
+                return $sheet;
             });
 
         $reader->close();
@@ -114,6 +117,7 @@ trait Importable
         $tempReader = $reader ?: $this->openReader($path);
 
         foreach ($tempReader->getSheetIterator() as $key => $sheet) {
+
             if($callback)
             {
                 $sheets->put($key, $callback($key, $sheet));


### PR DESCRIPTION
My shot on fixing #17.

There are still a couple of things to discuss about this repo's strategy, and the resulting `import()` method signature will become convoluted as features get added. But it's still 0.2.1, so that should be fine and understandable.

After merging this, I would suggest to work on how the lib is instantiated. I'm thinking maybe pulling the `$path` variable into `FastExcel.php` itself so that the method changes to `(new FastExcel('myfile.xlsx'))->doSomething`. I can see how you wanted to maintain flexibility as to when an import reads from (an export method saves to) a path, but as [mentioned in my comment](https://github.com/rap2hpoutre/fast-excel/commit/0aa4438cf89cdd4595fa79008353caf6d8fb3f39#diff-db62bfe9ae68587406c03f5ce8520867R122) there are some caveats to my current approach.

Furthermore interesting to delve into would be passing the respective callbacks into the FastExcel object using `public void setSheetListener($callback)` or similar methods and removing those from the `import()` method signature. But I didn't develop that yet as I wanted to hear what you think.

I'll be happy to hear back from you!