### PR TITLE
Bug fix

### DIFF
--- a/src/functions/fastexcel.php
+++ b/src/functions/fastexcel.php
@@ -12,6 +12,6 @@ if (!function_exists('fastexcel')) {
             $data = $data->toArray();
         }
 
-        return app()->makeWith('fastexcel', $data);
+        return blank($data) ? app()->make('fastexcel') : app()->makeWith('fastexcel', $data);
     }
 }


### PR DESCRIPTION
Laravel's ``makeWith`` method for the Application container requires an array as the second parameter. Since FastExcel can be instantiated without any constructor arguments, this fixes an Exception being thrown if it is instantiated without data.