### PR TITLE
Allow for import to not be stored in memory

### DIFF
--- a/src/Importable.php
+++ b/src/Importable.php
@@ -122,7 +122,13 @@ trait Importable
                 } elseif ($count_header < $count_row = count($row)) {
                     $row = array_slice($row, 0, $count_header);
                 }
-                $collection[] = $callback ? $callback(array_combine($headers, $row)) : array_combine($headers, $row);
+                if ($callback) {
+                    if ($result = $callback(array_combine($headers, $row))) {
+                        $collection[] = $result;
+                    }
+                } else {
+                    $collection[] = array_combine($headers, $row);
+                }
             }
         } else {
             foreach ($sheet->getRowIterator() as $row) {


### PR DESCRIPTION
Currently every row that gets imported gets inserted into a collection. For large imports (>100k records) this starts eating up memory. This change checks to see if the callback has returned a value before storing it in the collection. If there is a value it adds it to a collection, if not the collection stays empty and it moves on to the next record.