### PR TITLE
add null check for first_row in writeHeader

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -148,6 +148,10 @@ trait Exportable
 
     private function writeHeader($writer, $first_row)
     {
+        if($first_row === null) {
+            return;
+        }
+
         $keys = array_keys(is_array($first_row) ? $first_row : $first_row->toArray());
         if ($this->header_style) {
             $writer->addRowWithStyle($keys, $this->header_style);

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -148,7 +148,7 @@ trait Exportable
 
     private function writeHeader($writer, $first_row)
     {
-        if($first_row === null) {
+        if ($first_row === null) {
             return;
         }
 


### PR DESCRIPTION
This fixes #131, fixes #125 

Allows to always pass the result of a Eloquent query even if its empty, if empty a empty excel file will be generated instead of crashing on header generation.