### PR TITLE
add configure callbacks for Spout reader and writer

### DIFF
--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -3,6 +3,8 @@
 namespace Rap2hpoutre\FastExcel;
 
 use Box\Spout\Common\Type;
+use Box\Spout\Reader\ReaderInterface;
+use Box\Spout\Writer\WriterInterface;
 use Box\Spout\Reader\CSV\Reader as CSVReader;
 use Box\Spout\Writer\CSV\Writer as CSVWriter;
 use Illuminate\Support\Collection;
@@ -35,6 +37,16 @@ class FastExcel
         'encoding'  => 'UTF-8',
         'bom'       => true,
     ];
+
+    /**
+     * @var callable
+     */
+    protected $reader_configurator = null;
+
+    /**
+     * @var callable
+     */
+    protected $writer_configurator = null;
 
     /**
      * FastExcel constructor.
@@ -115,6 +127,34 @@ class FastExcel
     }
 
     /**
+     * Configure the underlying Spout Reader using a callback
+     *
+     * @param  callable  $callback
+     *
+     * @return FastExcel
+     */
+    public function configureReaderUsing(?callable $callback = null) : FastExcel
+    {
+        $this->reader_configurator = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Configure the underlying Spout Reader using a callback
+     *
+     * @param  callable  $callback
+     *
+     * @return FastExcel
+     */
+    public function configureWriterUsing(?callable $callback = null) : FastExcel
+    {
+        $this->writer_configurator = $callback;
+
+        return $this;
+    }
+
+    /**
      * @param \Box\Spout\Reader\ReaderInterface|\Box\Spout\Writer\WriterInterface $reader_or_writer
      */
     protected function setOptions(&$reader_or_writer)
@@ -129,6 +169,16 @@ class FastExcel
             if ($reader_or_writer instanceof CSVWriter) {
                 $reader_or_writer->setShouldAddBOM($this->csv_configuration['bom']);
             }
+        }
+
+        if ($reader_or_writer instanceof ReaderInterface && is_callable($this->reader_configurator)) {
+            call_user_func(
+                $this->reader_configurator, $reader_or_writer
+            );
+        } elseif ($reader_or_writer instanceof WriterInterface && is_callable($this->writer_configurator)) {
+            call_user_func(
+                $this->writer_configurator, $reader_or_writer
+            );
         }
     }
 }

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -3,10 +3,10 @@
 namespace Rap2hpoutre\FastExcel;
 
 use Box\Spout\Common\Type;
-use Box\Spout\Reader\ReaderInterface;
-use Box\Spout\Writer\WriterInterface;
 use Box\Spout\Reader\CSV\Reader as CSVReader;
+use Box\Spout\Reader\ReaderInterface;
 use Box\Spout\Writer\CSV\Writer as CSVWriter;
+use Box\Spout\Writer\WriterInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
@@ -127,13 +127,13 @@ class FastExcel
     }
 
     /**
-     * Configure the underlying Spout Reader using a callback
+     * Configure the underlying Spout Reader using a callback.
      *
-     * @param  callable  $callback
+     * @param callable $callback
      *
-     * @return FastExcel
+     * @return $this
      */
-    public function configureReaderUsing(?callable $callback = null) : FastExcel
+    public function configureReaderUsing(?callable $callback = null)
     {
         $this->reader_configurator = $callback;
 
@@ -141,13 +141,13 @@ class FastExcel
     }
 
     /**
-     * Configure the underlying Spout Reader using a callback
+     * Configure the underlying Spout Reader using a callback.
      *
-     * @param  callable  $callback
+     * @param callable $callback
      *
-     * @return FastExcel
+     * @return $this
      */
-    public function configureWriterUsing(?callable $callback = null) : FastExcel
+    public function configureWriterUsing(?callable $callback = null)
     {
         $this->writer_configurator = $callback;
 


### PR DESCRIPTION
fixes #83 

This makes it possible to get access to the Spout writer (and reader).
Since the writer/reader is created at the same moment when an export/import is initialized it's not possible to create a `getWriter`/`getReader` method.

This adds the methods `configureWriterUsing` and `configureReaderUsing` instead that makes it possible to register a callback that receives the underlying Spout writer/reader as the sole argument before the file is created/imported.

This also makes it future-proof to always allow access to new features that may be added to Spout without having to implement them in fast-excel.

Usage example:

```php
(new FastExcel($users))->configureWriterUsing(function ($writer) {
    $writer->setTempFolder('/path/to/temp/folder');
})->export('users.xlsx');
```

```php
$users = (new FastExcel())->configureReaderUsing(function ($reader) {
    $reader->setTempFolder('/path/to/temp/folder');
})->import('users.xlsx');