### PR TITLE
throw exception when using unsupported data

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -6,6 +6,7 @@ use Box\Spout\Writer\Style\Style;
 use Box\Spout\Writer\WriterFactory;
 use Generator;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 
 /**
  * Trait Exportable.
@@ -105,6 +106,8 @@ trait Exportable
                 $this->writeRowsFromGenerator($writer, $collection);
             } elseif (is_array($collection)) {
                 $this->writeRowsFromArray($writer, $collection, $callback);
+            } else {
+                throw new InvalidArgumentException('Unsupported type for $data');
             }
             if (is_string($key)) {
                 $writer->getCurrentSheet()->setName($key);

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -82,7 +82,7 @@ class IssuesTest extends TestCase
     public function testIssue26()
     {
         chdir(__DIR__);
-        foreach ([[[]], null, [null]] as $value) {
+        foreach ([[[]], [null]] as $value) {
             $path = (new FastExcel($value))->export('test2.xlsx');
             $this->assertEquals(collect([]), (new FastExcel())->import(__DIR__.'/test2.xlsx'));
             unlink($path);


### PR DESCRIPTION
PR to add exception when using bad data, as mentioned in #132 https://github.com/rap2hpoutre/fast-excel/pull/137#issuecomment-561354130

The only issue i could see with this is backward compatibility, but it should be low risk since no one should rely on using null as input to get an empty Excel-file.

One test was failing since it was testing that null-value was working, i don't know what the normal action here is (i'm quite bad at testing), but i removed that value from the test, the whole point of this PR is that null (and other bad input) should not be supported anyway.

You decide if this should be merged, i think it should be ok, never a bad thing to be explicit about what input is supported (instead of quietly failing/do nothing)