### PR TITLE
FIX Outdated Laravel Excel link and typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ a simple, but elegant wrapper around [Spout](https://github.com/box/spout) with 
 of simplifying **imports and exports**.
 
 It could be considered as a faster (and memory friendly) alternative
-to [Laravel Excel](https://laravel-excel.maatwebsite.nl/), with less features.
+to [Laravel Excel](https://laravel-excel.com/), with less features.
 Use it only for simple tasks.
 
 ## Benchmarks
@@ -195,5 +195,5 @@ Testing a XLSX export for 10000 lines, 20 columns with random data, 10 iteration
 | Laravel Excel  | 123.56 M  | 11.56 s |
 | FastExcel  | 2.09 M | 2.76 s |
 
-Still, remember that [Laravel Excel](https://laravel-excel.maatwebsite.nl/) **has many more feature.**
+Still, remember that [Laravel Excel](https://laravel-excel.com/) **has many more features.**
 Please help me improve benchmarks, more tests are coming. Feel free to criticize.


### PR DESCRIPTION
Old link redirects properly, but has a broken SSL cert.