### PR TITLE
add support of rows style

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -20,6 +20,7 @@ trait Exportable
      * @var Style
      */
     private $header_style;
+    private $rows_style;
 
     /**
      * @param string $path
@@ -134,7 +135,11 @@ trait Exportable
             $this->writeHeader($writer, $collection->first());
         }
         // Write all rows
-        $writer->addRows($collection->toArray());
+        if ($this->rows_style) {
+            $writer->addRowsWithStyle($collection->toArray(), $this->rows_style);
+        } else {
+            $writer->addRows($collection->toArray());
+        }
     }
 
     private function writeRowsFromGenerator($writer, Generator $generator, ?callable $callback = null)
@@ -153,7 +158,11 @@ trait Exportable
                 $this->writeHeader($writer, $item);
             }
             // Write rows (one by one).
-            $writer->addRow($item->toArray());
+            if ($this->rows_style) {
+                $writer->addRowWithStyle($item->toArray(), $this->rows_style);
+            } else {
+                $writer->addRow($item->toArray());
+            }
         }
     }
 
@@ -233,6 +242,18 @@ trait Exportable
     public function headerStyle(Style $style)
     {
         $this->header_style = $style;
+
+        return $this;
+    }
+
+    /**
+     * @param Style $style
+     *
+     * @return Exportable
+     */
+    public function rowsStyle(Style $style)
+    {
+        $this->rows_style = $style;
 
         return $this;
     }


### PR DESCRIPTION
With this version, you can add custom style base on [Spout Styling Guide](https://opensource.box.com/spout/docs/#styling) to all rows except headers.

Example:

```
$header_style = (new StyleBuilder())
    ->setFontBold()
    ->setBackgroundColor(Color::DARK_BLUE)
    ->setFontColor(Color::WHITE)
    ->build();

$border = (new BorderBuilder())
    ->setBorderBottom(Color::BLACK, Border::WIDTH_THIN, Border::STYLE_DASHED)
    ->build();

$style = (new StyleBuilder())
    ->setFontSize(15)
    ->setBorder($border)
    ->setFontColor(Color::BLUE)
    ->setShouldWrapText()
    ->setBackgroundColor("EDEDED")
    ->build();

return (new FastExcel($list))->headerStyle($header_style)->rowsStyle($style)->download('file.xlsx');
```