### PR TITLE
Allow a `SheetCollection` to be passed to the `fastexcel()` helper

### DIFF
--- a/src/functions/fastexcel.php
+++ b/src/functions/fastexcel.php
@@ -1,5 +1,7 @@
 <?php
 
+use Rap2hpoutre\FastExcel\SheetCollection;
+
 if (!function_exists('fastexcel')) {
     /**
      * Return app instance of FastExcel.
@@ -8,6 +10,10 @@ if (!function_exists('fastexcel')) {
      */
     function fastexcel($data = null)
     {
+        if ($data instanceof SheetCollection) {
+            return app()->make('fastexcel')->data($data);
+        }
+
         if (is_object($data) && method_exists($data, 'toArray')) {
             $data = $data->toArray();
         }


### PR DESCRIPTION
From the docs:

```php
$sheets = new SheetCollection([
    User::all(),
    Project::all()
]);
(new FastExcel($sheets))->export('file.xlsx');
```

However, this does not work:

```php
$sheets = new SheetCollection([
    User::all(),
    Project::all()
]);
fastexcel($sheets)->export('file.xlsx');
```

The current `fastexcel()` method checks if `$data` has a `toArray()` method, and if so, sets `$data = $data->toArray()`. Since `SheetCollection` has a `toArray()` method, it gets converted to an array and is no longer treated as a `SheetCollection` instance.

This PR adds a simple `instanceof SheetCollection` check that, when true, returns a new `FastExcel` instance with the `SheetCollection` properly set as the data.