### PR TITLE
patch GHSA-3p32-j457-pg5x vulnerability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "box/spout": "^2.7"
   },
   "require-dev": {
-    "illuminate/database": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || ^6.0 || ^7.0 || ^8.0",
+    "illuminate/database": "^6.20.12 || ^7.30.3 || ^8.22.1",
     "phpunit/phpunit": "^6.4"
   },
   "autoload": {


### PR DESCRIPTION
Also it breaks support for 5.* database version, so I guess it's a breaking change.