### PR TITLE
fix issue of inability to style xlsx rows

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -186,7 +186,7 @@ trait Exportable
         //style rows one by one
         foreach ($all_rows as $row) {
             $row = WriterEntityFactory::createRowFromArray($row->toArray(), $rows_style);
-            array_push($styled_rows,$row);
+            array_push($styled_rows, $row);
         }
         $writer->addRows($styled_rows);
     }

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -181,7 +181,7 @@ trait Exportable
         }
     }
 
-    private function addRowsWithStyle ($writer,$all_rows, $rows_style)
+    private function addRowsWithStyle($writer, $all_rows, $rows_style)
     {
         $styled_rows = [];
         // Style rows one by one

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -175,10 +175,20 @@ trait Exportable
             return WriterEntityFactory::createRowFromArray($value);
         })->toArray();
         if ($this->rows_style) {
-            $writer->addRowsWithStyle($all_rows, $this->rows_style);
+            $this->addRowsWithStyle($writer, $all_rows, $this->rows_style);
         } else {
             $writer->addRows($all_rows);
         }
+    }
+
+    private function addRowsWithStyle ($writer,$all_rows, $rows_style) {
+        $styled_rows = [];
+        //style rows one by one
+        foreach ($all_rows as $row) {
+            $row = WriterEntityFactory::createRowFromArray($row->toArray(), $rows_style);
+            array_push($styled_rows,$row);
+        }
+        $writer->addRows($styled_rows);
     }
 
     private function writeRowsFromGenerator($writer, Generator $generator, ?callable $callback = null)

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -181,7 +181,8 @@ trait Exportable
         }
     }
 
-    private function addRowsWithStyle ($writer,$all_rows, $rows_style) {
+    private function addRowsWithStyle ($writer,$all_rows, $rows_style)
+    {
         $styled_rows = [];
         // Style rows one by one
         foreach ($all_rows as $row) {

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -183,7 +183,7 @@ trait Exportable
 
     private function addRowsWithStyle ($writer,$all_rows, $rows_style) {
         $styled_rows = [];
-        //style rows one by one
+        // Style rows one by one
         foreach ($all_rows as $row) {
             $row = WriterEntityFactory::createRowFromArray($row->toArray(), $rows_style);
             array_push($styled_rows, $row);


### PR DESCRIPTION
Regarding this [issue](https://github.com/rap2hpoutre/fast-excel/issues/230)

**The problem is :**
   -  When trying to apply another style than default on rows of XLSX file, it doesn't get applied and the code crashes with this message 

> Call to undefined method Box\Spout\Writer\XLSX\Writer::addRowsWithStyle()

   - The reason for this problem is that Spout has changed to a new code that cannot be invoked the same old way.
I managed to track it down and solve it, hope it helps anybody who is looking for a solution. (_check the changed file to view the fix_)
 
![photo_٢٠٢١-٠٧-٢٦_١٣-٣٣-٥٢](https://user-images.githubusercontent.com/34798590/127367849-196bc2c5-cdb4-487a-b9f6-4dfe285277ea.jpg)

