### PR TITLE
Update type docblocks for export data

### DIFF
--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -6,6 +6,7 @@ use Box\Spout\Reader\CSV\Reader as CSVReader;
 use Box\Spout\Reader\ReaderInterface;
 use Box\Spout\Writer\CSV\Writer as CSVWriter;
 use Box\Spout\Writer\WriterInterface;
+use Generator;
 use Illuminate\Support\Collection;
 
 /**
@@ -16,7 +17,7 @@ class FastExcel
     use Importable;
     use Exportable;
     /**
-     * @var Collection
+     * @var Collection|Generator|array
      */
     protected $data;
 
@@ -58,7 +59,7 @@ class FastExcel
     /**
      * FastExcel constructor.
      *
-     * @param Collection $data
+     * @param Collection|Generator|array|null $data
      */
     public function __construct($data = null)
     {
@@ -68,7 +69,7 @@ class FastExcel
     /**
      * Manually set data apart from the constructor.
      *
-     * @param Collection $data
+     * @param Collection|Generator|array $data
      *
      * @return FastExcel
      */


### PR DESCRIPTION
This PR updates the type docblocks for export data, from only `Collection` to an union of `Collection`, `Generator` and `array`, to be in line with the types which are actually supported.

This fixes a false positive with static analyzers, example below with PHPStan

```
zarunet:[redacted] %> composer phpstan                                                                                                                                                            
> @php vendor/bin/phpstan --version

PHPStan - PHP Static Analysis Tool 0.12.94
> @php vendor/bin/phpstan analyse
Note: Using configuration file [redacted]/phpstan.neon.dist.
 493/493 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ -------------------------------------------------------------------------------------------------------------------------------------- 
  Line   [redacted].php                                                                             
 ------ -------------------------------------------------------------------------------------------------------------------------------------- 
  112    Parameter #1 $data of class Rap2hpoutre\FastExcel\FastExcel constructor expects Illuminate\Support\Collection|null, Generator given.  
 ------ -------------------------------------------------------------------------------------------------------------------------------------- 
```
