### PR TITLE
"openspout/openspout": "^4.6" so new package like powergrid can be in…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "openspout/openspout": "^3"
+        "openspout/openspout": "^4.6"
     },
     "require-dev": {
         "illuminate/database": "^6.20.12 || ^7.30.4 || ^8.24.0 || ^9.0",


### PR DESCRIPTION
`  Problem 1
    - Root composer.json requires rap2hpoutre/fast-excel ^4.1.0 -> satisfiable by rap2hpoutre/fast-excel[v4.1.0].
    - power-components/livewire-powergrid[v3.2.0, ..., v3.2.7] require openspout/openspout ^4.6 -> satisfiable by openspout/openspout[v4.6.0, v4.6.1, v4.6.2, 4.x-dev].
    - Conclusion: don't install openspout/openspout v4.6.2 (conflict analysis result)
    - Root composer.json requires power-components/livewire-powergrid ^3.2 -> satisfiable by power-components/livewire-powergrid[v3.2.0, ..., v3.2.7].`
 
As Laravel Nova required the Fast-Excel it's not possible for me to remove it 

