### PR TITLE
updated the styling instruction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,14 @@ function usersGenerator() {
 Add header and rows style with `headerStyle` and `rowsStyle` methods.
 
 ```php
-$header_style = (new StyleBuilder())->setFontBold()->build();
+use OpenSpout\Common\Entity\Style\Style;
 
-$rows_style = (new StyleBuilder())
+$header_style = (new Style())->setFontBold();
+
+$rows_style = (new Style())
     ->setFontSize(15)
     ->setShouldWrapText()
-    ->setBackgroundColor("EDEDED")
-    ->build();
+    ->setBackgroundColor("EDEDED");
 
 return (new FastExcel($list))
     ->headerStyle($header_style)


### PR DESCRIPTION
I noticed that the readme didn't capture the correct way to use the styling for both headers and rows which can be misleading to a lot of people when trying to work with this package. 