### PR TITLE
Attach `filename` to generate correct Content-Disposition header with PSR7 on Octane

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -67,7 +67,7 @@ trait Exportable
         if (method_exists(response(), 'streamDownload')) {
             return response()->streamDownload(function () use ($path, $callback) {
                 self::exportOrDownload($path, 'openToBrowser', $callback);
-            });
+            }, $path);
         }
         self::exportOrDownload($path, 'openToBrowser', $callback);
 


### PR DESCRIPTION
fixes #239