### PR TITLE
Allow Traversable as data in Export

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -10,6 +10,7 @@ use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Writer\Common\AbstractOptions;
 use OpenSpout\Writer\Common\Creator\WriterEntityFactory;
+use Traversable;
 
 /**
  * Trait Exportable.
@@ -110,7 +111,7 @@ trait Exportable
         foreach ($data as $key => $collection) {
             if ($collection instanceof Collection) {
                 $this->writeRowsFromCollection($writer, $collection, $callback);
-            } elseif ($collection instanceof Generator) {
+            } elseif ($collection instanceof Generator || $collection instanceof Traversable) {
                 $this->writeRowsFromGenerator($writer, $collection, $callback);
             } elseif (is_array($collection)) {
                 $this->writeRowsFromArray($writer, $collection, $callback);
@@ -199,7 +200,7 @@ trait Exportable
         $writer->addRows($styled_rows);
     }
 
-    private function writeRowsFromGenerator($writer, Generator $generator, ?callable $callback = null)
+    private function writeRowsFromGenerator($writer, Generator|Traversable $generator, ?callable $callback = null)
     {
         foreach ($generator as $key => $item) {
             // Apply callback

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -69,7 +69,7 @@ class FastExcel
     /**
      * Manually set data apart from the constructor.
      *
-     * @param Collection|Generator|array $data
+     * @param Collection|Generator|Traversable|array $data
      *
      * @return FastExcel
      */


### PR DESCRIPTION
This is useful if you want to pass an object of a class that implements IteratorAggregate as data