### PR TITLE
Improve performance: make service provider deferred

### DIFF
--- a/src/Providers/FastExcelServiceProvider.php
+++ b/src/Providers/FastExcelServiceProvider.php
@@ -3,19 +3,10 @@
 namespace Rap2hpoutre\FastExcel\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Support\DeferrableProvider;
 
-class FastExcelServiceProvider extends ServiceProvider
+class FastExcelServiceProvider extends ServiceProvider implements DeferrableProvider
 {
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        //
-    }
-
     /**
      * Register any application services.
      *
@@ -32,5 +23,17 @@ class FastExcelServiceProvider extends ServiceProvider
 
             return new \Rap2hpoutre\FastExcel\FastExcel($data);
         });
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides(): array
+    {
+        return [
+            'fastexcel',
+        ];
     }
 }

--- a/src/Providers/FastExcelServiceProvider.php
+++ b/src/Providers/FastExcelServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Rap2hpoutre\FastExcel\Providers;
 
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Support\ServiceProvider;
 
 class FastExcelServiceProvider extends ServiceProvider implements DeferrableProvider
 {


### PR DESCRIPTION
From official docs:
>If your provider is only registering bindings in the [service container](https://laravel.com/docs/master/container), you may choose to defer its registration until one of the registered bindings is actually needed. Deferring the loading of such a provider will improve the performance of your application, since it is not loaded from the filesystem on every request.

https://laravel.com/docs/master/providers#deferred-providers