### PR TITLE
Don't filter out DateTime values

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -2,6 +2,7 @@
 
 namespace Rap2hpoutre\FastExcel;
 
+use DateTimeInterface;
 use Generator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -280,7 +281,7 @@ trait Exportable
         return collect($data)->map(function ($value) {
             return is_null($value) ? (string) $value : $value;
         })->filter(function ($value) {
-            return is_string($value) || is_int($value) || is_float($value);
+            return is_string($value) || is_int($value) || is_float($value) || $value instanceof DateTimeInterface;
         });
     }
 


### PR DESCRIPTION
Currently all values other than string, int or float are filtered out in the `transformRows` method of `Eportable`. Since openspout does support DateTime values (see: https://github.com/openspout/openspout/blob/4.x/src/Writer/XLSX/Manager/WorksheetManager.php#L202-L203), we want to keep these values.

Note that [openspout/openspout](https://github.com/openspout/openspout) probably needs some attention as well. DateTime values are converted to Excel-compatible Date values (floats), and while it is possible to apply a date formatting to all cells of all rows, that's probably not what you want since this might incorrectly apply the style non-date values that look like Excel-dates. I'll try to implement a fix for them that optionally allows to set a formatting per column.