### PR TITLE
Implement per cell styling for openspout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,10 @@
         "xlsx"
     ],
     "description": "Fast Excel import/export for Laravel",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/jschram/openspout.git"
-        }
-    ],
     "require": {
         "php": "^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
-        "openspout/openspout": "4.x-dev"
+        "openspout/openspout": "^4.24"
     },
     "require-dev": {
         "illuminate/database": "^6.20.12 || ^7.30.4 || ^8.24.0 || ^9.0 || ^10.0 || ^11.0",

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,16 @@
         "xlsx"
     ],
     "description": "Fast Excel import/export for Laravel",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/jschram/openspout.git"
+        }
+    ],
     "require": {
         "php": "^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
-        "openspout/openspout": "^4.1.1"
+        "openspout/openspout": "4.x-dev"
     },
     "require-dev": {
         "illuminate/database": "^6.20.12 || ^7.30.4 || ^8.24.0 || ^9.0 || ^10.0 || ^11.0",

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -2,6 +2,7 @@
 
 namespace Rap2hpoutre\FastExcel;
 
+use DateTimeInterface;
 use Generator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -280,7 +281,7 @@ trait Exportable
         return collect($data)->map(function ($value) {
             return is_null($value) ? (string) $value : $value;
         })->filter(function ($value) {
-            return is_string($value) || is_int($value) || is_float($value);
+            return is_string($value) || is_int($value) || is_float($value) || $value instanceof DateTimeInterface;
         });
     }
 

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -27,12 +27,23 @@ trait Exportable
     private $header_style;
     private $rows_style;
 
+    /** @var Style[] */
+    private $column_styles = [];
+
     /**
      * @param AbstractOptions $options
      *
      * @return mixed
      */
     abstract protected function setOptions(&$options);
+
+    /** @param Style[] $styles */
+    public function setColumnStyles($styles): static
+    {
+        $this->column_styles = $styles;
+
+        return $this;
+    }
 
     /**
      * @param string        $path
@@ -183,19 +194,19 @@ trait Exportable
         $all_rows = $collection->map(function ($value) {
             return Row::fromValues($value);
         })->toArray();
-        if ($this->rows_style) {
-            $this->addRowsWithStyle($writer, $all_rows, $this->rows_style);
+        if ($this->rows_style || count($this->column_styles)) {
+            $this->addRowsWithStyle($writer, $all_rows, $this->rows_style, $this->column_styles);
         } else {
             $writer->addRows($all_rows);
         }
     }
 
-    private function addRowsWithStyle($writer, $all_rows, $rows_style)
+    private function addRowsWithStyle($writer, $all_rows, $rows_style, $column_styles)
     {
         $styled_rows = [];
         // Style rows one by one
         foreach ($all_rows as $row) {
-            $styled_rows[] = Row::fromValues($row->toArray(), $rows_style);
+            $styled_rows[] = Row::fromValues($row->toArray(), $rows_style, $column_styles);
         }
         $writer->addRows($styled_rows);
     }
@@ -216,7 +227,7 @@ trait Exportable
                 $this->writeHeader($writer, $item);
             }
             // Write rows (one by one).
-            $writer->addRow(Row::fromValues($item->toArray(), $this->rows_style));
+            $writer->addRow(Row::fromValues($item->toArray(), $this->rows_style, $this->column_styles));
         }
     }
 

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -321,7 +321,7 @@ trait Exportable
     }
 
     /**
-     * Create openspout row from values with optional row and cell styling
+     * Create openspout row from values with optional row and cell styling.
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
      */

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -206,7 +206,7 @@ trait Exportable
         $styled_rows = [];
         // Style rows one by one
         foreach ($all_rows as $row) {
-            $styled_rows[] = Row::fromValues($row->toArray(), $rows_style, $column_styles);
+            $styled_rows[] = $this->createRow($row->toArray(), $rows_style, $column_styles);
         }
         $writer->addRows($styled_rows);
     }
@@ -227,7 +227,7 @@ trait Exportable
                 $this->writeHeader($writer, $item);
             }
             // Write rows (one by one).
-            $writer->addRow(Row::fromValues($item->toArray(), $this->rows_style, $this->column_styles));
+            $writer->addRow($this->createRow($item->toArray(), $this->rows_style, $this->column_styles));
         }
     }
 
@@ -248,7 +248,7 @@ trait Exportable
         }
 
         $keys = array_keys(is_array($first_row) ? $first_row : $first_row->toArray());
-        $writer->addRow(Row::fromValues($keys, $this->header_style));
+        $writer->addRow($this->createRow($keys, $this->header_style));
 //        $writer->addRow(WriterEntityFactory::createRowFromArray($keys, $this->header_style));
     }
 
@@ -318,5 +318,15 @@ trait Exportable
         $this->rows_style = $style;
 
         return $this;
+    }
+
+    /**
+     * Create openspout row from values with optional row and cell styling
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
+    private function createRow(array $values = [], ?Style $rows_style = null, array $column_styles = []): Row
+    {
+        return Row::fromValuesWithStyles($values, $rows_style, $column_styles);
     }
 }

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -73,9 +73,9 @@ class FastExcelTest extends TestCase
      * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
      * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
-    private function export($file, $override_collection = null)
+    private function export($file)
     {
-        $original_collection = $override_collection ?? $this->collection();
+        $original_collection = $this->collection();
 
         (new FastExcel(clone $original_collection))->export($file);
         $this->assertEquals($original_collection, (new FastExcel())->import($file));

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -4,6 +4,7 @@ namespace Rap2hpoutre\FastExcel\Tests;
 
 use OpenSpout\Common\Entity\Style\Color;
 use OpenSpout\Common\Entity\Style\Style;
+use OpenSpout\Common\Exception\IOException;
 use OpenSpout\Reader\XLSX\Options;
 use Rap2hpoutre\FastExcel\FastExcel;
 use Rap2hpoutre\FastExcel\SheetCollection;
@@ -13,6 +14,31 @@ use Rap2hpoutre\FastExcel\SheetCollection;
  */
 class FastExcelTest extends TestCase
 {
+    /**
+     * @throws IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     */
+    public function testExportXlsxWithDates()
+    {
+        $collection = collect([
+            ['col1' => new \DateTimeImmutable('1980-09-18 00:00:00.000000')],
+            ['col1' => new \DateTimeImmutable('2018-07-02 00:00:00.000000')],
+        ]);
+
+        $file = __DIR__ . '/test-dates-export.xlsx';
+        (new FastExcel(clone $collection))
+            ->setColumnStyles([
+                0 => (new Style())->setFormat('mm/dd/yyyy'),
+            ])
+            ->export($file);
+
+        $this->assertEquals($collection, (new FastExcel())->import($file));
+        unlink($file);
+    }
+
     /**
      * @throws \OpenSpout\Common\Exception\IOException
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
@@ -47,9 +73,9 @@ class FastExcelTest extends TestCase
      * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
      * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
-    private function export($file)
+    private function export($file, $override_collection = null)
     {
-        $original_collection = $this->collection();
+        $original_collection = $override_collection ?? $this->collection();
 
         (new FastExcel(clone $original_collection))->export($file);
         $this->assertEquals($original_collection, (new FastExcel())->import($file));

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -28,7 +28,7 @@ class FastExcelTest extends TestCase
             ['col1' => new \DateTimeImmutable('2018-07-02 00:00:00.000000')],
         ]);
 
-        $file = __DIR__ . '/test-dates-export.xlsx';
+        $file = __DIR__.'/test-dates-export.xlsx';
         (new FastExcel(clone $collection))
             ->setColumnStyles([
                 0 => (new Style())->setFormat('mm/dd/yyyy'),


### PR DESCRIPTION
It would be nice to be able to format certain values as numeric, date, etc. 
To achieve this, DateTime values should be accepted as well, from within `Exportable::transformRows`. There already is support in openspout for DateTime values (see: [Writer\XLSX\Manager\WorksheetManager](https://github.com/openspout/openspout/blob/4.x/src/Writer/XLSX/Manager/WorksheetManager.php#L202-L203)). So, I've made a contribution to openspout/openspout that allows a full Row to be created from an array with styling per cell. This was merged today and a new version has been tagged. See: https://github.com/openspout/openspout/pull/235

This PR implements this change, allowing users to set the formatting of certain columns (based on their numeric index) when exporting data.

For instance:
```php
(new FastExcel(clone $collection))
    ->setColumnStyles([
        0 => (new Style())->setFormat('mm/dd/yyyy'),
    ])
    ->export($file);
```
