### PR TITLE
feat: Add sheet context to importSheets callback

### DIFF
--- a/src/Facades/FastExcel.php
+++ b/src/Facades/FastExcel.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureCsv($delimiter = ',', $enclosure = '"', $encoding = 'UTF-8', $bom = false)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureReaderUsing(?callable $callback = null)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureWriterUsing(?callable $callback = null)
+ * @method static \Rap2hpoutre\FastExcel\FastExcel withSheetContext()
  *
  * @see \Rap2hpoutre\FastExcel\FastExcel
  */

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -123,6 +123,18 @@ class FastExcel
     }
 
     /**
+     * Enable passing sheet name to callback
+     *
+     * @return $this
+     */
+    public function withSheetContext()
+    {
+        $this->with_sheet_context = true;
+
+        return $this;
+    }
+
+    /**
      * @return $this
      */
     public function transpose()

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -123,7 +123,7 @@ class FastExcel
     }
 
     /**
-     * Enable passing sheet name to callback
+     * Enable passing sheet name to callback.
      *
      * @return $this
      */

--- a/src/Importable.php
+++ b/src/Importable.php
@@ -21,6 +21,10 @@ trait Importable
      * @var int
      */
     private $sheet_number = 1;
+    /**
+     * @var bool
+     */
+    private $with_sheet_context = false;
 
     /**
      * @param AbstractOptions $options
@@ -147,6 +151,7 @@ trait Importable
         $headers = [];
         $collection = [];
         $count_header = 0;
+        $sheetName = $sheet->getName();
 
         foreach ($sheet->getRowIterator() as $k => $rowAsObject) {
             $row = array_map(function (Cell $cell) {
@@ -169,12 +174,21 @@ trait Importable
                         $row = array_slice($row, 0, $count_header);
                     }
                 }
+
+                $rowData = empty($headers) ? $row : array_combine($headers, $row);
+
                 if ($callback) {
-                    if ($result = $callback(empty($headers) ? $row : array_combine($headers, $row))) {
+                    if ($this->with_sheet_context) {
+                        $result = $callback($sheetName, $rowData);
+                    } else {
+                        $result = $callback($rowData);
+                    }
+
+                    if ($result) {
                         $collection[] = $result;
                     }
                 } else {
-                    $collection[] = empty($headers) ? $row : array_combine($headers, $row);
+                    $collection[] = $rowData;
                 }
             }
         }


### PR DESCRIPTION
# Add sheet name to importSheets callback function

## Description
This PR enhances the `importSheets` method by allowing callback functions to receive the current sheet name as the first parameter. This is useful for data validation, especially when the same field names exist across different sheets.

The implementation adds a new `withSheetContext()` method that, when called, will make `importSheets` pass the sheet name as the first parameter to the callback function.

@rap2hpoutre This PR solves that issue [https://github.com/rap2hpoutre/fast-excel/issues/366](https://github.com/rap2hpoutre/fast-excel/issues/366)

## Changes
- Added `$with_sheet_context` property to the `Importable` trait
- Added `withSheetContext()` method to enable the feature
- Modified `importSheet()` method to conditionally pass sheet name to callback
- Updated facade documentation with the new method

## Backwards Compatibility
This change maintains full backwards compatibility:
- Existing code continues to work without modification
- New functionality is opt-in via the `withSheetContext()` method

## Usage Example
```php
$collections = (new FastExcel)
    ->withSheetContext()
    ->importSheets('file.xlsx', function ($sheetName, $row) {
        // Perform sheet-specific validation
        if ($sheetName === 'Users' && empty($row['email'])) {
            return null; // Skip rows without email in Users sheet
        }
        
        // Add sheet information to result
        $row['_sheet'] = $sheetName;
        
        return $row;
    });