### PR TITLE
Fix php84 deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.1, 8.2, 8.3 ]
+        php: [ 8.1, 8.2, 8.3, 8.4 ]
         stability: [ lowest, highest ]
 
     steps:

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -56,7 +56,7 @@ trait Exportable
      *
      * @return string
      */
-    public function export($path, callable $callback = null)
+    public function export($path, ?callable $callback = null)
     {
         self::exportOrDownload($path, 'openToFile', $callback);
 
@@ -74,7 +74,7 @@ trait Exportable
      *
      * @return \Symfony\Component\HttpFoundation\StreamedResponse|string
      */
-    public function download($path, callable $callback = null)
+    public function download($path, ?callable $callback = null)
     {
         if (method_exists(response(), 'streamDownload')) {
             return response()->streamDownload(function () use ($path, $callback) {
@@ -97,7 +97,7 @@ trait Exportable
      * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      * @throws \OpenSpout\Common\Exception\SpoutException
      */
-    private function exportOrDownload($path, $function, callable $callback = null)
+    private function exportOrDownload($path, $function, ?callable $callback = null)
     {
         if (Str::endsWith($path, 'csv')) {
             $options = new \OpenSpout\Writer\CSV\Options();

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -61,7 +61,7 @@ class FastExcel
      *
      * @param array|Generator|Collection|null $data
      */
-    public function __construct(array|Generator|Collection $data = null)
+    public function __construct(array|Generator|Collection|null $data = null)
     {
         $this->data = $data;
     }

--- a/src/Importable.php
+++ b/src/Importable.php
@@ -39,7 +39,7 @@ trait Importable
      *
      * @return Collection
      */
-    public function import($path, callable $callback = null)
+    public function import($path, ?callable $callback = null)
     {
         $reader = $this->reader($path);
 
@@ -64,7 +64,7 @@ trait Importable
      *
      * @return Collection
      */
-    public function importSheets($path, callable $callback = null)
+    public function importSheets($path, ?callable $callback = null)
     {
         $reader = $this->reader($path);
 
@@ -142,7 +142,7 @@ trait Importable
      *
      * @return array
      */
-    private function importSheet(SheetInterface $sheet, callable $callback = null)
+    private function importSheet(SheetInterface $sheet, ?callable $callback = null)
     {
         $headers = [];
         $collection = [];


### PR DESCRIPTION
This PR extends [#363](https://github.com/rap2hpoutre/fast-excel/pull/363) by [@JeppeKnockaert](https://github.com/JeppeKnockaert), rebased onto current master.

It fixes PHP 8.4 deprecation warnings caused by implicitly nullable parameter declarations in fast-excel (reported in [#365](https://github.com/rap2hpoutre/fast-excel/issues/365)).

Original work by JeppeKnockaert:

Replace implicit nullable parameters with explicit ? types
Add PHP 8.4 to the CI test matrix
Additional change in this PR:

Merge latest master so Laravel 12/13 support (#377) is retained in composer.json