### PR TITLE
Feature/configure writer using

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -11,12 +11,14 @@ use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Writer\Common\AbstractOptions;
 use OpenSpout\Writer\Common\Creator\WriterEntityFactory;
+use OpenSpout\Writer\WriterInterface;
 
 /**
  * Trait Exportable.
  *
  * @property bool                           $transpose
  * @property bool                           $with_header
+ * @property callable|null                  $writer_configurator
  * @property \Illuminate\Support\Collection $data
  */
 trait Exportable
@@ -99,19 +101,7 @@ trait Exportable
      */
     private function exportOrDownload($path, $function, callable $callback = null)
     {
-        if (Str::endsWith($path, 'csv')) {
-            $options = new \OpenSpout\Writer\CSV\Options();
-            $writer = new \OpenSpout\Writer\CSV\Writer($options);
-        } elseif (Str::endsWith($path, 'ods')) {
-            $options = new \OpenSpout\Writer\ODS\Options();
-            $writer = new \OpenSpout\Writer\ODS\Writer($options);
-        } else {
-            $options = new \OpenSpout\Writer\XLSX\Options();
-            $writer = new \OpenSpout\Writer\XLSX\Writer($options);
-        }
-
-        $this->setOptions($options);
-        /* @var \OpenSpout\Writer\WriterInterface $writer */
+        $writer = $this->makeWriter($path);
         $writer->$function($path);
 
         $has_sheets = ($writer instanceof \OpenSpout\Writer\XLSX\Writer || $writer instanceof \OpenSpout\Writer\ODS\Writer);
@@ -137,6 +127,52 @@ trait Exportable
             }
         }
         $writer->close();
+    }
+
+    private function makeWriter(string $path): WriterInterface
+    {
+        $extension = $this->resolveWriterExtension($path);
+
+        if ($extension === 'csv') {
+            $options = new \OpenSpout\Writer\CSV\Options();
+        } elseif ($extension === 'ods') {
+            $options = new \OpenSpout\Writer\ODS\Options();
+        } else {
+            $options = new \OpenSpout\Writer\XLSX\Options();
+        }
+
+        $this->setOptions($options);
+
+        if (is_callable($this->writer_configurator ?? null)) {
+            $writer = call_user_func($this->writer_configurator, $options, $extension);
+
+            if ($writer instanceof WriterInterface) {
+                return $writer;
+            }
+        }
+
+        if ($extension === 'csv') {
+            return new \OpenSpout\Writer\CSV\Writer($options);
+        }
+
+        if ($extension === 'ods') {
+            return new \OpenSpout\Writer\ODS\Writer($options);
+        }
+
+        return new \OpenSpout\Writer\XLSX\Writer($options);
+    }
+
+    private function resolveWriterExtension(string $path): string
+    {
+        if (Str::endsWith($path, 'csv')) {
+            return 'csv';
+        }
+
+        if (Str::endsWith($path, 'ods')) {
+            return 'ods';
+        }
+
+        return 'xlsx';
     }
 
     /**

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -5,7 +5,6 @@ namespace Rap2hpoutre\FastExcel;
 use DateTimeInterface;
 use Generator;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use InvalidArgumentException;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Entity\Style\Style;
@@ -164,11 +163,11 @@ trait Exportable
 
     private function resolveWriterExtension(string $path): string
     {
-        if (Str::endsWith($path, 'csv')) {
+        if (str_ends_with($path, 'csv')) {
             return 'csv';
         }
 
-        if (Str::endsWith($path, 'ods')) {
+        if (str_ends_with($path, 'ods')) {
             return 'ods';
         }
 

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -11,12 +11,14 @@ use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Writer\Common\AbstractOptions;
 use OpenSpout\Writer\Common\Creator\WriterEntityFactory;
+use OpenSpout\Writer\WriterInterface;
 
 /**
  * Trait Exportable.
  *
  * @property bool                           $transpose
  * @property bool                           $with_header
+ * @property callable|null                  $writer_configurator
  * @property \Illuminate\Support\Collection $data
  */
 trait Exportable
@@ -99,19 +101,7 @@ trait Exportable
      */
     private function exportOrDownload($path, $function, ?callable $callback = null)
     {
-        if (Str::endsWith($path, 'csv')) {
-            $options = new \OpenSpout\Writer\CSV\Options();
-            $writer = new \OpenSpout\Writer\CSV\Writer($options);
-        } elseif (Str::endsWith($path, 'ods')) {
-            $options = new \OpenSpout\Writer\ODS\Options();
-            $writer = new \OpenSpout\Writer\ODS\Writer($options);
-        } else {
-            $options = new \OpenSpout\Writer\XLSX\Options();
-            $writer = new \OpenSpout\Writer\XLSX\Writer($options);
-        }
-
-        $this->setOptions($options);
-        /* @var \OpenSpout\Writer\WriterInterface $writer */
+        $writer = $this->makeWriter($path);
         $writer->$function($path);
 
         $has_sheets = ($writer instanceof \OpenSpout\Writer\XLSX\Writer || $writer instanceof \OpenSpout\Writer\ODS\Writer);
@@ -137,6 +127,52 @@ trait Exportable
             }
         }
         $writer->close();
+    }
+
+    private function makeWriter(string $path): WriterInterface
+    {
+        $extension = $this->resolveWriterExtension($path);
+
+        if ($extension === 'csv') {
+            $options = new \OpenSpout\Writer\CSV\Options();
+        } elseif ($extension === 'ods') {
+            $options = new \OpenSpout\Writer\ODS\Options();
+        } else {
+            $options = new \OpenSpout\Writer\XLSX\Options();
+        }
+
+        $this->setOptions($options);
+
+        if (is_callable($this->writer_configurator ?? null)) {
+            $writer = call_user_func($this->writer_configurator, $options, $extension);
+
+            if ($writer instanceof WriterInterface) {
+                return $writer;
+            }
+        }
+
+        if ($extension === 'csv') {
+            return new \OpenSpout\Writer\CSV\Writer($options);
+        }
+
+        if ($extension === 'ods') {
+            return new \OpenSpout\Writer\ODS\Writer($options);
+        }
+
+        return new \OpenSpout\Writer\XLSX\Writer($options);
+    }
+
+    private function resolveWriterExtension(string $path): string
+    {
+        if (Str::endsWith($path, 'csv')) {
+            return 'csv';
+        }
+
+        if (Str::endsWith($path, 'ods')) {
+            return 'ods';
+        }
+
+        return 'xlsx';
     }
 
     /**

--- a/src/Facades/FastExcel.php
+++ b/src/Facades/FastExcel.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureCsv($delimiter = ',', $enclosure = '"', $encoding = 'UTF-8', $bom = false)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureReaderUsing(?callable $callback = null)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureWriterUsing(?callable $callback = null)
+ * @method static \Rap2hpoutre\FastExcel\FastExcel configureOptionsUsing(?callable $callback = null)
  *
  * @see \Rap2hpoutre\FastExcel\FastExcel
  */

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -52,9 +52,14 @@ class FastExcel
     ];
 
     /**
-     * @var callable
+     * @var callable|null
      */
     protected $options_configurator = null;
+
+    /**
+     * @var callable|null
+     */
+    protected $writer_configurator = null;
 
     /**
      * FastExcel constructor.
@@ -163,17 +168,20 @@ class FastExcel
     }
 
     /**
-     * Configure the underlying Spout Reader using a callback.
+     * Configure a custom writer factory using a callback.
      *
-     * @param callable|null $callback
+     * The callback receives the configured options and file extension
+     * ('csv', 'ods' or 'xlsx') and should return a \OpenSpout\Writer\WriterInterface instance.
+     * Return null to fall back to the default writer for that extension.
+     *
+     * @param callable|null $callback function (AbstractOptions $options, string $extension): ?\OpenSpout\Writer\WriterInterface
      *
      * @return $this
-     *
-     * @deprecated Has no effect with spout v4
-     * @see        configureOptionsUsing
      */
     public function configureWriterUsing(?callable $callback = null)
     {
+        $this->writer_configurator = $callback;
+
         return $this;
     }
 

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -249,9 +249,54 @@ class FastExcelTest extends TestCase
 
     /**
      * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
      * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
      */
+    public function testConfigureWriterUsingWithCustomCsvWriter()
+    {
+        $usedCustomWriter = false;
+        $original_collection = $this->collection();
+        $file = __DIR__.'/test-custom-writer.csv';
+
+        (new FastExcel(clone $original_collection))
+            ->configureWriterUsing(function ($options, $extension) use (&$usedCustomWriter) {
+                $this->assertEquals('csv', $extension);
+                $this->assertInstanceOf(\OpenSpout\Writer\CSV\Options::class, $options);
+                $usedCustomWriter = true;
+
+                return new \OpenSpout\Writer\CSV\Writer($options);
+            })
+            ->export($file);
+
+        $this->assertTrue($usedCustomWriter);
+        $this->assertEquals($original_collection, (new FastExcel())->import($file));
+        unlink($file);
+    }
+
+    /**
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     */
+    public function testConfigureWriterUsingFallbackToDefaultWriter()
+    {
+        $original_collection = $this->collection();
+        $file = __DIR__.'/test-writer-fallback.csv';
+
+        (new FastExcel(clone $original_collection))
+            ->configureWriterUsing(function ($options, $extension) {
+                return null;
+            })
+            ->export($file);
+
+        $this->assertEquals($original_collection, (new FastExcel())->import($file));
+        unlink($file);
+    }
+
     public function testImportXlsxWithCustomDateOption()
     {
         // Default options, dates will end parsed


### PR DESCRIPTION

`configureCsv()` and `configureOptionsUsing()` only mutate OpenSpout options. They do not let callers choose or replace the writer instance. This adds an opt-in hook for that, without changing the `FastExcel` constructor.
## Changes
- Implement `configureWriterUsing()` via a new internal `makeWriter()` helper
- Callback receives `($options, $extension)` and may return a `WriterInterface`
- Return `null` (or a non-writer) to fall back to the default CSV/ODS/XLSX writer
- Add tests for custom writer usage and fallback behavior
## Usage
```php
(new FastExcel($rows))
    ->configureWriterUsing(function ($options, $extension) {
        if ($extension === 'csv') {
         
            return new \OpenSpout\Writer\CSV\Writer($options);
        }
        return null;
    })
    ->download('export.csv');
```
    
## Backward compatibility
Fully backward compatible. Existing exports are unchanged when configureWriterUsing() is not used.