### PR TITLE
Fix #185: import uploaded / extension-less CSV & ODS files

### DIFF
--- a/src/Importable.php
+++ b/src/Importable.php
@@ -3,7 +3,6 @@
 namespace Rap2hpoutre\FastExcel;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Reader\SheetInterface;
 use OpenSpout\Writer\Common\AbstractOptions;
@@ -30,8 +29,8 @@ trait Importable
     abstract protected function setOptions(&$options);
 
     /**
-     * @param string        $path
-     * @param callable|null $callback
+     * @param string|\Symfony\Component\HttpFoundation\File\UploadedFile $path
+     * @param callable|null                                              $callback
      *
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
      * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
@@ -55,8 +54,8 @@ trait Importable
     }
 
     /**
-     * @param string        $path
-     * @param callable|null $callback
+     * @param string|\Symfony\Component\HttpFoundation\File\UploadedFile $path
+     * @param callable|null                                              $callback
      *
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
      * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
@@ -82,7 +81,7 @@ trait Importable
     }
 
     /**
-     * @param $path
+     * @param string|object $path
      *
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
      * @throws \OpenSpout\Common\Exception\IOException
@@ -91,11 +90,13 @@ trait Importable
      */
     private function reader($path)
     {
-        if (Str::endsWith($path, 'csv')) {
+        $type = $this->readerType($path);
+
+        if ($type === 'csv') {
             $options = new \OpenSpout\Reader\CSV\Options();
             $this->setOptions($options);
             $reader = new \OpenSpout\Reader\CSV\Reader($options);
-        } elseif (Str::endsWith($path, 'ods')) {
+        } elseif ($type === 'ods') {
             $options = new \OpenSpout\Reader\ODS\Options();
             $this->setOptions($options);
             $reader = new \OpenSpout\Reader\ODS\Reader($options);
@@ -106,9 +107,173 @@ trait Importable
         }
 
         /* @var \OpenSpout\Reader\ReaderInterface $reader */
-        $reader->open($path);
+        $reader->open($this->readerPath($path));
 
         return $reader;
+    }
+
+    /**
+     * Resolve the reader type (csv|ods|xlsx) for the given path or uploaded file.
+     *
+     * Files uploaded through a form are stored under an extension-less temporary
+     * path (e.g. /tmp/phpXXXX), so the type cannot be guessed from the path alone.
+     * In that case we rely on the uploaded file's original extension / mime type,
+     * falling back to sniffing the file contents.
+     *
+     * @param string|object $path
+     *
+     * @return string
+     */
+    private function readerType($path): string
+    {
+        // Illuminate/Symfony UploadedFile (duck-typed to avoid a hard dependency).
+        if (is_object($path) && method_exists($path, 'getClientOriginalExtension')) {
+            $extension = strtolower((string) $path->getClientOriginalExtension());
+            if (in_array($extension, ['csv', 'ods', 'xlsx'], true)) {
+                return $extension;
+            }
+
+            $mime = method_exists($path, 'getClientMimeType') ? (string) $path->getClientMimeType() : '';
+
+            return $this->readerTypeFromMime($mime, $this->readerPath($path));
+        }
+
+        $path = (string) $path;
+
+        if (str_ends_with($path, 'csv')) {
+            return 'csv';
+        }
+        if (str_ends_with($path, 'ods')) {
+            return 'ods';
+        }
+        if (str_ends_with($path, 'xlsx')) {
+            return 'xlsx';
+        }
+
+        // No recognizable extension (e.g. an uploaded temp file): sniff the contents.
+        return $this->readerTypeFromMime($this->guessMimeType($path), $path);
+    }
+
+    /**
+     * Map a mime type to a reader type, sniffing the file as a last resort.
+     *
+     * @param string $mime
+     * @param string $path
+     *
+     * @return string
+     */
+    private function readerTypeFromMime(string $mime, string $path): string
+    {
+        $mime = strtolower($mime);
+
+        if (str_contains($mime, 'csv')) {
+            return 'csv';
+        }
+        if (str_contains($mime, 'opendocument.spreadsheet')) {
+            return 'ods';
+        }
+        if (str_contains($mime, 'spreadsheetml') || str_contains($mime, 'officedocument')) {
+            return 'xlsx';
+        }
+
+        return $this->sniffReaderType($mime, $path);
+    }
+
+    /**
+     * Determine the reader type when the mime type is inconclusive by inspecting
+     * the file contents.
+     *
+     * @param string $mime
+     * @param string $path
+     *
+     * @return string
+     */
+    private function sniffReaderType(string $mime, string $path): string
+    {
+        // XLSX and ODS are zip archives; distinguish them by peeking inside.
+        if (is_file($path) && $this->isZipArchive($path)) {
+            return $this->zipContains($path, 'mimetype', 'opendocument.spreadsheet') ? 'ods' : 'xlsx';
+        }
+
+        // Plain delimited text with no zip signature: treat as CSV.
+        if ($mime === '' || str_starts_with($mime, 'text/')) {
+            return 'csv';
+        }
+
+        return 'xlsx';
+    }
+
+    /**
+     * @param string|object $path
+     *
+     * @return string
+     */
+    private function readerPath($path): string
+    {
+        if (is_object($path) && method_exists($path, 'getPathname')) {
+            return (string) $path->getPathname();
+        }
+
+        return (string) $path;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return string
+     */
+    private function guessMimeType($path): string
+    {
+        if (is_file($path) && function_exists('mime_content_type')) {
+            $mime = @mime_content_type($path);
+            if ($mime !== false) {
+                return $mime;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return bool
+     */
+    private function isZipArchive($path): bool
+    {
+        $handle = @fopen($path, 'rb');
+        if ($handle === false) {
+            return false;
+        }
+        $signature = fread($handle, 2);
+        fclose($handle);
+
+        return $signature === 'PK';
+    }
+
+    /**
+     * Check whether a zip entry's content contains a given needle.
+     *
+     * @param string $path
+     * @param string $entry
+     * @param string $needle
+     *
+     * @return bool
+     */
+    private function zipContains($path, $entry, $needle): bool
+    {
+        if (!class_exists(\ZipArchive::class)) {
+            return false;
+        }
+
+        $zip = new \ZipArchive();
+        if ($zip->open($path) !== true) {
+            return false;
+        }
+        $content = $zip->getFromName($entry);
+        $zip->close();
+
+        return is_string($content) && str_contains($content, $needle);
     }
 
     /**

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -210,8 +210,18 @@ class IssuesTest extends TestCase
         copy(__DIR__.'/test104.xlsx', $xlsxNoExt);
         $this->assertCount(3, (new FastExcel())->import($xlsxNoExt));
 
+        // An ODS stored under an extension-less path is detected by sniffing the
+        // zip mimetype entry (ODS and XLSX are both zip archives).
+        $ods = __DIR__.'/issue_185.ods';
+        (new FastExcel($this->collection()))->export($ods);
+        $odsNoExt = tempnam(sys_get_temp_dir(), 'php');
+        copy($ods, $odsNoExt);
+        $this->assertEquals($this->collection(), (new FastExcel())->import($odsNoExt));
+
         unlink($csvNoExt);
         unlink($xlsxNoExt);
+        unlink($odsNoExt);
+        unlink($ods);
     }
 
     /**
@@ -260,7 +270,15 @@ class IssuesTest extends TestCase
         $csvUploadNoExt = $makeUploadedFile(__DIR__.'/test2.csv', 'data', 'text/csv');
         $this->assertCount(3, (new FastExcel())->import($csvUploadNoExt));
 
+        // ODS uploaded file, resolved from its original extension.
+        $ods = __DIR__.'/issue_185_upload.ods';
+        (new FastExcel($this->collection()))->export($ods);
+        $odsUpload = $makeUploadedFile($ods, 'book.ods', 'application/vnd.oasis.opendocument.spreadsheet');
+        $this->assertEquals($this->collection(), (new FastExcel())->import($odsUpload));
+
         unlink($csvUpload->getPathname());
         unlink($csvUploadNoExt->getPathname());
+        unlink($odsUpload->getPathname());
+        unlink($ods);
     }
 }

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -188,4 +188,79 @@ class IssuesTest extends TestCase
 
         unlink($file);
     }
+
+    /**
+     * Issue #185: importing an uploaded CSV/ODS fails because the format is
+     * guessed from the path extension, and uploaded files live under an
+     * extension-less temporary path (e.g. /tmp/phpXXXX).
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testIssue185()
+    {
+        // A CSV stored under an extension-less path must be detected by content.
+        $csvNoExt = tempnam(sys_get_temp_dir(), 'php');
+        copy(__DIR__.'/test2.csv', $csvNoExt);
+        $this->assertCount(3, (new FastExcel())->import($csvNoExt));
+
+        // An XLSX stored under an extension-less path must still work.
+        $xlsxNoExt = tempnam(sys_get_temp_dir(), 'php');
+        copy(__DIR__.'/test104.xlsx', $xlsxNoExt);
+        $this->assertCount(3, (new FastExcel())->import($xlsxNoExt));
+
+        unlink($csvNoExt);
+        unlink($xlsxNoExt);
+    }
+
+    /**
+     * Issue #185: importing directly from an UploadedFile-like object should
+     * resolve the format from its original extension / client mime type.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testIssue185UploadedFile()
+    {
+        $makeUploadedFile = function (string $source, string $originalName, string $mime) {
+            $tmp = tempnam(sys_get_temp_dir(), 'php');
+            copy($source, $tmp);
+
+            // Duck-typed stand-in for Illuminate/Symfony UploadedFile so the
+            // test does not require illuminate/http to be installed.
+            return new class($tmp, $originalName, $mime) {
+                public function __construct(private string $tmp, private string $name, private string $mime)
+                {
+                }
+
+                public function getClientOriginalExtension(): string
+                {
+                    return pathinfo($this->name, PATHINFO_EXTENSION);
+                }
+
+                public function getClientMimeType(): string
+                {
+                    return $this->mime;
+                }
+
+                public function getPathname(): string
+                {
+                    return $this->tmp;
+                }
+            };
+        };
+
+        // Resolved from the original extension.
+        $csvUpload = $makeUploadedFile(__DIR__.'/test2.csv', 'data.csv', 'text/csv');
+        $this->assertCount(3, (new FastExcel())->import($csvUpload));
+
+        // Resolved from the client mime type when the original name has no extension.
+        $csvUploadNoExt = $makeUploadedFile(__DIR__.'/test2.csv', 'data', 'text/csv');
+        $this->assertCount(3, (new FastExcel())->import($csvUploadNoExt));
+
+        unlink($csvUpload->getPathname());
+        unlink($csvUploadNoExt->getPathname());
+    }
 }


### PR DESCRIPTION
## Problem

Importing an uploaded CSV (or ODS) file fails with:

> `Could not open /tmp/phpXXXX for reading: Not a zip archive.`

This is the long-standing issue reported in #185 (and duplicated in a few others). The reader format is chosen purely from the **path extension**:

```php
if (Str::endsWith($path, 'csv'))      { ... CSV reader }
elseif (Str::endsWith($path, 'ods'))  { ... ODS reader }
else                                  { ... XLSX reader } // default
```

A form-uploaded file lives under an **extension-less temporary path** (`/tmp/phpXXXX`), so a CSV/ODS upload always falls through to the XLSX (zip) reader and throws. XLSX uploads "work" only because they happen to match the default branch.

### Confirmed (PHP 8.4, current `master`)

| Scenario | Before |
|----------|--------|
| CSV at extension-less temp path | ❌ `Not a zip archive` |
| Same CSV with `.csv` extension | ✅ |
| XLSX at extension-less temp path | ✅ |

## Fix

`reader()` now resolves the type in order:

1. **Path extension** — unchanged behaviour for `*.csv` / `*.ods` / `*.xlsx`.
2. **`UploadedFile`** — uses the original extension, then the client mime type. Duck-typed (`method_exists(...)`) so it works with Illuminate/Symfony `UploadedFile` **without adding a dependency**.
3. **Content sniffing** — for an extension-less path, falls back to `mime_content_type()` and a zip-signature peek (`PK` + `mimetype` entry) to tell CSV / ODS / XLSX apart.

`import()` / `importSheets()` now also accept an `UploadedFile` directly, so this just works:

```php
(new FastExcel)->import($request->file('file'));
```

No behaviour change for existing string paths with extensions.

## Tests

Added regression tests (`testIssue185`, `testIssue185UploadedFile`) covering extension-less CSV/XLSX paths and `UploadedFile`-style imports (via a duck-typed stand-in, no `illuminate/http` requirement). Full suite green (27 tests).

Fixes #185.