### PR TITLE
ci: add PHP 8.5 to the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.1, 8.2, 8.3, 8.4 ]
+        php: [ 8.1, 8.2, 8.3, 8.4, 8.5 ]
         stability: [ lowest, highest ]
 
     steps:


### PR DESCRIPTION
Adds PHP **8.5** to the CI test matrix (now `[ 8.1, 8.2, 8.3, 8.4, 8.5 ]`).

### Context
This supersedes #375. That PR aimed to "test against php 8.4 and 8.5", but it was branched off an older `master` (`[ 8.1, 8.2, 8.3 ]`) and now conflicts because **8.4 already landed on `master`**. The only remaining delta was 8.5, which this one-line change adds cleanly on top of current `master`.

Closes the 8.5 gap so we catch 8.5 regressions early. CI on this PR will confirm the suite is green on 8.5.