### PR TITLE
docs: add issue templates, PR template, and CONTRIBUTING guide

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,9 @@
+---
+# Codacy configuration.
+# FastExcel is a small library — the value of static analysis is in the PHP
+# source. Docs, GitHub config, and Markdown shouldn't fail the quality gate,
+# so they're excluded from analysis to keep pull-request checks meaningful.
+exclude_paths:
+  - '.github/**'
+  - '**/*.md'
+  - 'docs/**'

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -5,5 +5,5 @@
 # so they're excluded from analysis to keep pull-request checks meaningful.
 exclude_paths:
   - '.github/**'
-  - '**/*.md'
+  - '**.md'
   - 'docs/**'

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: 🐞 Bug report
+description: Report a reproducible bug in FastExcel
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please fill in as much as you can —
+        a minimal reproduction is the single biggest factor in getting a fix.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+        - label: I'm on the latest version of `rap2hpoutre/fast-excel`.
+          required: true
+  - type: input
+    id: package-version
+    attributes:
+      label: FastExcel version
+      placeholder: e.g. v5.7.0
+    validations:
+      required: true
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP version
+      placeholder: e.g. 8.3
+    validations:
+      required: true
+  - type: input
+    id: laravel-version
+    attributes:
+      label: Laravel version
+      placeholder: e.g. 11.x (or "none / standalone")
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: A minimal code sample that triggers the bug. Include the file type (xlsx/csv/ods) if relevant.
+      render: php
+      placeholder: |
+        $rows = (new FastExcel)->import('file.csv');
+        // ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the full error message / stack trace if there is one.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might help (sample file, screenshots, etc.).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Question / "How do I…?"
+    url: https://github.com/rap2hpoutre/fast-excel#docs
+    about: Usage questions belong in the README first, then Stack Overflow. The issue tracker is for bugs and feature requests only.
+  - name: 🔎 Search existing issues
+    url: https://github.com/rap2hpoutre/fast-excel/issues?q=is%3Aissue
+    about: Your problem may already be reported or answered. Please search before opening a new issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: 💡 Feature request
+description: Suggest a new capability or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        FastExcel aims to stay small and fast. Please describe the use case, not just the solution —
+        it helps us keep the API minimal.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched existing issues and didn't find a similar request.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that FastExcel doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like it to work? A code sketch of the desired API is welcome.
+      render: php
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--
+Thanks for contributing to FastExcel! Please keep PRs small and focused.
+-->
+
+## What does this PR do?
+
+<!-- A clear description of the change and why it's needed. Link any related issue, e.g. "Fixes #123". -->
+
+## Checklist
+
+- [ ] Targets the `master` branch
+- [ ] The change is focused (one logical change per PR)
+- [ ] Added or updated tests in `tests/`
+- [ ] `composer test` passes locally
+- [ ] Code style is consistent with the codebase (StyleCI will check automatically)
+- [ ] Updated the `README.md` if the public API changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to FastExcel
+
+Thanks for your interest in improving FastExcel! This guide covers everything you
+need to get a change merged.
+
+## Philosophy
+
+FastExcel is a small, fast wrapper around [OpenSpout](https://github.com/openspout/openspout).
+The goal is a minimal, intuitive API — not to expose every OpenSpout feature. When
+proposing a change, lead with the **use case** so we can keep the surface area small.
+
+## Reporting issues
+
+- **Bugs and feature requests** go in the [issue tracker](https://github.com/rap2hpoutre/fast-excel/issues),
+  using the provided templates.
+- **Usage questions** ("how do I…?") are best asked on Stack Overflow after checking
+  the [README](README.md). The tracker is reserved for bugs and feature requests.
+- Always **search existing issues** first — and include a minimal reproduction.
+
+## Development setup
+
+```bash
+git clone https://github.com/rap2hpoutre/fast-excel.git
+cd fast-excel
+composer install
+```
+
+## Running the tests
+
+```bash
+composer test
+```
+
+All new behavior should come with a test. Tests live in `tests/`; bug fixes that
+close an issue are usually added to `tests/IssuesTest.php` as `testIssue<number>()`.
+
+## Code style
+
+Code style is enforced automatically by **StyleCI** on every pull request — if it
+flags something, apply the suggested fix. To stay consistent with the existing code:
+
+- No spaces around string concatenation: `$a.$b` (not `$a . $b`).
+- Keep multi-line PHPDoc `@param` blocks vertically aligned.
+- Prefer native PHP functions over helpers where equivalent (e.g. `str_ends_with()`).
+
+## Submitting a pull request
+
+1. Branch off `master` (fork the repo if you don't have push access).
+2. Keep the PR **focused** — one logical change. Smaller PRs get reviewed faster.
+3. Add tests and make sure `composer test` passes.
+4. Open the PR against `master` and fill in the template.
+5. Make sure CI is green (build matrix + StyleCI).
+
+## Supported versions
+
+FastExcel targets **PHP 8.0+** and the actively supported Laravel releases. CI runs
+the suite across the PHP versions listed in
+[`.github/workflows/tests.yml`](.github/workflows/tests.yml); please make sure your
+change works across that range.
+
+Thanks again — every fix and improvement helps! 🙌


### PR DESCRIPTION
Lowers the contribution barrier and should reduce issue-tracker noise.

### What's added
- **`.github/ISSUE_TEMPLATE/`**
  - `bug_report.yml` — structured bug form (version, PHP/Laravel, repro, expected/actual), auto-labels `bug`.
  - `feature_request.yml` — use-case-first feature form, auto-labels `enhancement`.
  - `config.yml` — disables blank issues and routes **"how do I…?" usage questions** to the README / Stack Overflow. A large share of current open issues are usage questions; this should cut that down.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — checklist (targets master, focused change, tests, `composer test`, StyleCI, README).
- **`CONTRIBUTING.md`** — setup, running tests, the code-style rules StyleCI enforces (no-space concat, aligned PHPDoc), and the branch/PR workflow.

### Notes
- Auto-labels assume `bug` / `enhancement` labels exist (they do).
- No code changes — docs/templates only.