### PR TITLE
test: cover Eloquent model export/import (#12)

### DIFF
--- a/tests/EloquentModelTest.php
+++ b/tests/EloquentModelTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Rap2hpoutre\FastExcel\Tests;
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+use OpenSpout\Common\Exception\IOException;
+use Rap2hpoutre\FastExcel\FastExcel;
+
+/**
+ * Class EloquentModelTest.
+ */
+class EloquentModelTest extends TestCase
+{
+    /**
+     * Issue #12: export and re-import a real Eloquent model collection
+     * (backed by an in-memory SQLite database), so model attributes round-trip
+     * through the writer/reader and not just plain collections.
+     *
+     * @throws IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     */
+    public function testExportAndImportEloquentModels()
+    {
+        $capsule = new Capsule();
+        $capsule->addConnection(['driver' => 'sqlite', 'database' => ':memory:']);
+        $capsule->setAsGlobal();
+        $capsule->bootEloquent();
+
+        $capsule->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email');
+        });
+
+        $user = new User();
+        $user->newQuery()->insert([
+            ['name' => 'Joe', 'email' => 'joe@example.com'],
+            ['name' => 'Jane', 'email' => 'jane@example.com'],
+        ]);
+
+        $file = __DIR__.'/issue_12.xlsx';
+        (new FastExcel($user->newQuery()->get()))->export($file);
+
+        $imported = (new FastExcel())->import($file);
+
+        $this->assertCount(2, $imported);
+        $this->assertEquals(['id', 'name', 'email'], array_keys($imported[0]));
+        $this->assertEquals('Joe', $imported[0]['name']);
+        $this->assertEquals('joe@example.com', $imported[0]['email']);
+        $this->assertEquals('Jane', $imported[1]['name']);
+
+        $capsule->schema()->drop('users');
+        unlink($file);
+    }
+}

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -2,7 +2,6 @@
 
 namespace Rap2hpoutre\FastExcel\Tests;
 
-use Illuminate\Database\Capsule\Manager as Capsule;
 use OpenSpout\Common\Entity\Style\Color;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Common\Exception\IOException;
@@ -275,49 +274,5 @@ class FastExcelTest extends TestCase
             ['col1' => '1/2/2022'],
             ['col1' => '1/3/2022'],
         ]), $collection);
-    }
-
-    /**
-     * Issue #12: export and re-import a real Eloquent model collection
-     * (backed by an in-memory SQLite database), so model attributes round-trip
-     * through the writer/reader and not just plain collections.
-     *
-     * @throws IOException
-     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
-     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
-     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
-     */
-    public function testExportAndImportEloquentModels()
-    {
-        $capsule = new Capsule();
-        $capsule->addConnection(['driver' => 'sqlite', 'database' => ':memory:']);
-        $capsule->setAsGlobal();
-        $capsule->bootEloquent();
-
-        $capsule->schema()->create('users', function ($table) {
-            $table->increments('id');
-            $table->string('name');
-            $table->string('email');
-        });
-
-        $user = new User();
-        $user->newQuery()->insert([
-            ['name' => 'Joe', 'email' => 'joe@example.com'],
-            ['name' => 'Jane', 'email' => 'jane@example.com'],
-        ]);
-
-        $file = __DIR__.'/issue_12.xlsx';
-        (new FastExcel($user->newQuery()->get()))->export($file);
-
-        $imported = (new FastExcel())->import($file);
-
-        $this->assertCount(2, $imported);
-        $this->assertEquals(['id', 'name', 'email'], array_keys($imported[0]));
-        $this->assertEquals('Joe', $imported[0]['name']);
-        $this->assertEquals('joe@example.com', $imported[0]['email']);
-        $this->assertEquals('Jane', $imported[1]['name']);
-
-        $capsule->schema()->drop('users');
-        unlink($file);
     }
 }

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -3,7 +3,6 @@
 namespace Rap2hpoutre\FastExcel\Tests;
 
 use Illuminate\Database\Capsule\Manager as Capsule;
-use Illuminate\Database\Eloquent\Model;
 use OpenSpout\Common\Entity\Style\Color;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Common\Exception\IOException;
@@ -301,19 +300,13 @@ class FastExcelTest extends TestCase
             $table->string('email');
         });
 
-        $user = new class extends Model {
-            protected $table = 'users';
-            public $timestamps = false;
-            protected $fillable = ['name', 'email'];
-        };
-
-        $user->newQuery()->insert([
+        User::query()->insert([
             ['name' => 'Joe', 'email' => 'joe@example.com'],
             ['name' => 'Jane', 'email' => 'jane@example.com'],
         ]);
 
         $file = __DIR__.'/issue_12.xlsx';
-        (new FastExcel($user->newQuery()->get()))->export($file);
+        (new FastExcel(User::all()))->export($file);
 
         $imported = (new FastExcel())->import($file);
 

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -2,6 +2,8 @@
 
 namespace Rap2hpoutre\FastExcel\Tests;
 
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Eloquent\Model;
 use OpenSpout\Common\Entity\Style\Color;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Common\Exception\IOException;
@@ -274,5 +276,54 @@ class FastExcelTest extends TestCase
             ['col1' => '1/2/2022'],
             ['col1' => '1/3/2022'],
         ]), $collection);
+    }
+
+    /**
+     * Issue #12: export and re-import a real Eloquent model collection
+     * (backed by an in-memory SQLite database), so model attributes round-trip
+     * through the writer/reader and not just plain collections.
+     *
+     * @throws IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     */
+    public function testExportAndImportEloquentModels()
+    {
+        $capsule = new Capsule();
+        $capsule->addConnection(['driver' => 'sqlite', 'database' => ':memory:']);
+        $capsule->setAsGlobal();
+        $capsule->bootEloquent();
+
+        $capsule->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email');
+        });
+
+        $user = new class extends Model {
+            protected $table = 'users';
+            public $timestamps = false;
+            protected $fillable = ['name', 'email'];
+        };
+
+        $user->newQuery()->insert([
+            ['name' => 'Joe', 'email' => 'joe@example.com'],
+            ['name' => 'Jane', 'email' => 'jane@example.com'],
+        ]);
+
+        $file = __DIR__.'/issue_12.xlsx';
+        (new FastExcel($user->newQuery()->get()))->export($file);
+
+        $imported = (new FastExcel())->import($file);
+
+        $this->assertCount(2, $imported);
+        $this->assertEquals(['id', 'name', 'email'], array_keys($imported[0]));
+        $this->assertEquals('Joe', $imported[0]['name']);
+        $this->assertEquals('joe@example.com', $imported[0]['email']);
+        $this->assertEquals('Jane', $imported[1]['name']);
+
+        $capsule->schema()->drop('users');
+        unlink($file);
     }
 }

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -300,13 +300,14 @@ class FastExcelTest extends TestCase
             $table->string('email');
         });
 
-        User::query()->insert([
+        $user = new User();
+        $user->newQuery()->insert([
             ['name' => 'Joe', 'email' => 'joe@example.com'],
             ['name' => 'Jane', 'email' => 'jane@example.com'],
         ]);
 
         $file = __DIR__.'/issue_12.xlsx';
-        (new FastExcel(User::all()))->export($file);
+        (new FastExcel($user->newQuery()->get()))->export($file);
 
         $imported = (new FastExcel())->import($file);
 

--- a/tests/User.php
+++ b/tests/User.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rap2hpoutre\FastExcel\Tests;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class User.
+ *
+ * Minimal Eloquent model used to test exporting/importing model collections.
+ */
+class User extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = ['name', 'email'];
+}


### PR DESCRIPTION
Closes #12.

That issue (from 2018) noted the suite only tested plain collections, not models. This adds a test that exercises a **real Eloquent model** end to end:

- boots an in-memory SQLite database via Eloquent's `Capsule`,
- inserts a couple of model rows,
- exports the model collection to xlsx and re-imports it,
- asserts the attributes (`id`, `name`, `email`) round-trip through the writer/reader.

`illuminate/database` is already a dev dependency, so no new requirements. No production code changes — test only.