### PR TITLE
docs: add security policy (SECURITY.md)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest `5.x` release. Please make sure you're on
+the most recent version before reporting an issue.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.x     | :white_check_mark: |
+| < 5.0   | :x:                |
+
+## Reporting a vulnerability
+
+Please **do not open a public GitHub issue** for security vulnerabilities.
+
+Instead, report them privately to the maintainer, Raphaël Huchet
+(@rap2hpoutre), by email:
+
+**raphaelht@gmail.com**
+
+Include as much detail as you can — affected version, a description of the issue,
+and steps to reproduce. We'll acknowledge your report, work on a fix, and credit
+you in the release notes if you'd like.
+
+Thanks for helping keep FastExcel and its users safe.


### PR DESCRIPTION
Adds a `SECURITY.md` so GitHub's **Security → Policy** page is populated and reporters are directed to disclose vulnerabilities **privately by email** to @rap2hpoutre (raphaelht@gmail.com) rather than opening a public issue.

This came up in #354 (someone asked where to report security issues). Docs only — no code changes.