### PR TITLE
docs: show that export() returns the written file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ $list = collect([
     [ 'id' => 2, 'name' => 'John' ],
 ]);
 
-(new FastExcel($list))->export('file.xlsx');
+// export() returns the absolute path to the written file
+$path = (new FastExcel($list))->export('file.xlsx');
 ```
 
 Export `xlsx`, `ods` and `csv`:


### PR DESCRIPTION
Documents that `export()` returns the absolute path to the written file (`return realpath($path)`), by capturing the value in the basic example:

```php
// export() returns the absolute path to the written file
$path = (new FastExcel($list))->export('file.xlsx');
```

Supersedes #247, which added a `// return path...` comment above a line that discarded the return value. Docs only.

Closes #247.