### PR TITLE
ci: exclude tests/ from Codacy analysis

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,9 +1,11 @@
 ---
 # Codacy configuration.
 # FastExcel is a small library — the value of static analysis is in the PHP
-# source. Docs, GitHub config, and Markdown shouldn't fail the quality gate,
-# so they're excluded from analysis to keep pull-request checks meaningful.
+# source. Docs, GitHub config, Markdown, and tests shouldn't fail the quality
+# gate, so they're excluded from analysis to keep pull-request checks meaningful.
+# (Test classes legitimately trip method-count and duplication heuristics.)
 exclude_paths:
   - '.github/**'
   - '**.md'
   - 'docs/**'
+  - 'tests/**'


### PR DESCRIPTION
Adds `tests/**` to `.codacy.yaml`'s `exclude_paths`.

Test classes legitimately trip Codacy's code-quality heuristics in ways that aren't real problems:
- **TooManyPublicMethods** — `*Test` classes accumulate `testX()` methods well past the 10-method threshold by design (e.g. `IssuesTest` already has 14+). Every new test then shows up as a "new issue" because the method count in the message changes.
- **Duplication** — the `export()` → `import()` → `assert` → `unlink()` pattern repeats across tests by nature.

These fail Codacy's "0 new issues" gate on otherwise-clean test PRs (it bit #388 and #391). Static analysis is valuable on `src/`, not test scaffolding, so this scopes Codacy accordingly — consistent with the existing `.github/`, `**.md`, and `docs/` exclusions.

Config only. Takes effect once on `master` (Codacy reads its config from the default branch).