### PR TITLE
chore: modernize .gitattributes export-ignore list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,10 @@
-# Ignore all test and documentation for archive
+# Files and directories excluded from the Composer dist archive.
 /.github            export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /.scrutinizer.yml   export-ignore
-/.travis.yml        export-ignore
-/phpunit.xml.dist   export-ignore
+/.codacy.yaml       export-ignore
+/phpcs.xml          export-ignore
 /phpunit.xml        export-ignore
+/CONTRIBUTING.md    export-ignore
 /tests              export-ignore
-/docs               export-ignore


### PR DESCRIPTION
Follow-up to #253 (just merged). Brings the `export-ignore` list up to date with the current repo so the Composer `dist` archive stays lean:

**Added** (dev/config files that didn't exist when #253 was written):
- `.codacy.yaml`
- `phpcs.xml`
- `CONTRIBUTING.md`

**Removed** (entries for files that no longer exist):
- `.travis.yml`, `phpunit.xml.dist`, `docs/`

`README.md`, `LICENSE`, `CHANGELOG.md`, `SECURITY.md`, `composer.json`, and `src/` still ship in the dist, as expected. Every remaining entry was verified to exist on `master`. Also adds the trailing newline that #253 was missing.