### PR TITLE
Handle duplicate and empty header names on import

### DIFF
--- a/src/Importable.php
+++ b/src/Importable.php
@@ -324,7 +324,7 @@ trait Importable
             if ($k >= $this->start_row) {
                 if ($this->with_header) {
                     if ($k == $this->start_row) {
-                        $headers = $this->toStrings($row);
+                        $headers = $this->uniqueHeaders($this->toStrings($row));
                         $count_header = count($headers);
                         continue;
                     }
@@ -369,5 +369,39 @@ trait Importable
         }
 
         return $values;
+    }
+
+    /**
+     * Make header names usable as array keys. Empty headers get a positional
+     * name (`column_N`) and duplicated headers are de-duplicated: the first
+     * occurrence is kept and later ones get a numeric suffix (`Name`, `Name_2`).
+     * Without this, columns that share a name collide in array_combine() and
+     * their values are silently lost.
+     *
+     * @param array $headers
+     *
+     * @return array
+     */
+    private function uniqueHeaders(array $headers)
+    {
+        $used = [];
+        foreach ($headers as $index => $header) {
+            $header = (string) $header;
+            if ($header === '') {
+                $header = 'column_'.($index + 1);
+            }
+
+            $base = $header;
+            $suffix = 1;
+            while (isset($used[$header])) {
+                $suffix++;
+                $header = $base.'_'.$suffix;
+            }
+
+            $used[$header] = true;
+            $headers[$index] = $header;
+        }
+
+        return $headers;
     }
 }

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -281,4 +281,32 @@ class IssuesTest extends TestCase
         unlink($odsUpload->getPathname());
         unlink($ods);
     }
+
+    /**
+     * Issues #312 and #259: a header row with duplicate or empty names must not
+     * lose data. Duplicates keep the first occurrence and get a numeric suffix,
+     * empty headers get a positional name, so no column collides in the result.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testIssue312()
+    {
+        // Header row with a duplicate ("Name") and an empty column.
+        $file = __DIR__.'/issue_312.csv';
+        file_put_contents($file, "Name,Name,,Age\nJoe,Smith,x,30\nJane,Doe,y,25\n");
+
+        $rows = (new FastExcel())->import($file);
+
+        $first = $rows->first();
+        $this->assertSame(['Name', 'Name_2', 'column_3', 'Age'], array_keys($first));
+        $this->assertSame('Joe', $first['Name']);
+        $this->assertSame('Smith', $first['Name_2']);   // would have been lost before
+        $this->assertSame('x', $first['column_3']);
+        $this->assertSame('30', $first['Age']);
+        $this->assertCount(2, $rows);
+
+        unlink($file);
+    }
 }


### PR DESCRIPTION
### Problem
When an imported header row has **duplicate** names (e.g. two `Name` columns) or **empty** cells, `array_combine($headers, $row)` collapses the colliding keys and the extra columns' data is **silently lost**.

### Fix
Header names are normalized before they're used as array keys:
- **Empty** headers get a positional name: `column_1`, `column_3`, …
- **Duplicates** keep the first occurrence and suffix the rest: `Name`, `Name_2`, `Name_3` (the suffix loop also avoids colliding with a pre-existing `Name_2` column).

```php
// header row: Name | Name | (empty) | Age
$rows->first(); // ['Name' => ..., 'Name_2' => ..., 'column_3' => ..., 'Age' => ...]
```

Adds `testIssue312` covering a header row with a duplicate and an empty column.

### Relationship to existing PRs
This reworks the idea from **#312** (which only handled duplicates) to also cover **empty** headers (**#259**), and avoids the `array_count_values()` warnings that #312 triggers on non-string header cells (empty/float/date). Once this merges I'll close #312 and #259 with credit to their authors.