### PR TITLE
ci: align phpcs.xml with the codebase's concatenation style

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -130,6 +130,15 @@
 
     <rule ref="PSR1"/>
     <rule ref="PSR2"/>
-    <rule ref="PSR12"/>
+    <rule ref="PSR12">
+        <!--
+            The codebase follows the Laravel style (no spaces around string
+            concatenation, e.g. __DIR__.'/file'), which is what StyleCI enforces.
+            PSR12.Operators.OperatorSpacing requires spaces, contradicting that
+            and producing false positives on every concatenation. Disable it so
+            phpcs agrees with the actual code style (and stops failing Codacy).
+        -->
+        <exclude name="PSR12.Operators.OperatorSpacing"/>
+    </rule>
 
 </ruleset>


### PR DESCRIPTION
The repo's `phpcs.xml` enforces `PSR12.Operators.OperatorSpacing`, which requires **spaces around string concatenation** (`$a . $b`). But the entire codebase — and the **StyleCI** gate — use the Laravel style with **no spaces** (`__DIR__.'/file'`). The two configs directly contradict each other.

Nothing runs `phpcs` in CI or composer scripts — only **Codacy** consumes `phpcs.xml`. So this contradiction means **every `src/` PR that concatenates strings fails Codacy's gate** with false positives that can't be fixed without breaking StyleCI (e.g. #395).

This excludes just that one sniff, so phpcs agrees with the actual code style. Other PSR1/PSR2/PSR12 checks are untouched; `phpcs src/` is clean.

Config only. Like `.codacy.yaml`, it takes effect for Codacy once on the default branch.