### PR TITLE
Accept any Traversable as export data

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -3,7 +3,6 @@
 namespace Rap2hpoutre\FastExcel;
 
 use DateTimeInterface;
-use Generator;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use OpenSpout\Common\Entity\Row;
@@ -11,6 +10,7 @@ use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Writer\Common\AbstractOptions;
 use OpenSpout\Writer\Common\Creator\WriterEntityFactory;
 use OpenSpout\Writer\WriterInterface;
+use Traversable;
 
 /**
  * Trait Exportable.
@@ -111,7 +111,7 @@ trait Exportable
         foreach ($data as $key => $collection) {
             if ($collection instanceof Collection) {
                 $this->writeRowsFromCollection($writer, $collection, $callback);
-            } elseif ($collection instanceof Generator) {
+            } elseif ($collection instanceof Traversable) {
                 $this->writeRowsFromGenerator($writer, $collection, $callback);
             } elseif (is_array($collection)) {
                 $this->writeRowsFromArray($writer, $collection, $callback);
@@ -246,7 +246,7 @@ trait Exportable
         $writer->addRows($styled_rows);
     }
 
-    private function writeRowsFromGenerator($writer, Generator $generator, ?callable $callback = null)
+    private function writeRowsFromGenerator($writer, Traversable $generator, ?callable $callback = null)
     {
         foreach ($generator as $key => $item) {
             // Apply callback

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -2,11 +2,11 @@
 
 namespace Rap2hpoutre\FastExcel;
 
-use Generator;
 use Illuminate\Support\Collection;
 use OpenSpout\Reader\CSV\Options as CsvReaderOptions;
 use OpenSpout\Writer\Common\AbstractOptions;
 use OpenSpout\Writer\CSV\Options as CsvWriterOptions;
+use Traversable;
 
 /**
  * Class FastExcel.
@@ -17,7 +17,7 @@ class FastExcel
     use Exportable;
 
     /**
-     * @var Collection|Generator|array
+     * @var Collection|Traversable|array
      */
     protected $data;
 
@@ -64,9 +64,9 @@ class FastExcel
     /**
      * FastExcel constructor.
      *
-     * @param array|Generator|Collection|null $data
+     * @param array|Traversable|null $data
      */
-    public function __construct(array|Generator|Collection|null $data = null)
+    public function __construct(array|Traversable|null $data = null)
     {
         $this->data = $data;
     }
@@ -74,7 +74,7 @@ class FastExcel
     /**
      * Manually set data apart from the constructor.
      *
-     * @param Collection|Generator|array $data
+     * @param Collection|Traversable|array $data
      *
      * @return FastExcel
      */

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -107,6 +107,27 @@ class FastExcelTest extends TestCase
     }
 
     /**
+     * Export data given as any Traversable (e.g. an Iterator), not only a
+     * Collection, Generator or array.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testExportFromTraversable()
+    {
+        // ArrayIterator is a Traversable that is neither a Generator nor a Collection.
+        $data = new \ArrayIterator($this->collection()->toArray());
+
+        $file = (new FastExcel($data))->export(__DIR__.'/test2.xlsx');
+        $this->assertEquals($this->collection(), (new FastExcel())->import(__DIR__.'/test2.xlsx'));
+
+        unlink($file);
+    }
+
+    /**
      * @throws \OpenSpout\Common\Exception\IOException
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
      * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException


### PR DESCRIPTION
### What
Export previously accepted only a `Collection`, `Generator`, or `array`. This broadens it to accept **any `Traversable`** (e.g. an `Iterator`, `IteratorAggregate`, etc.), so custom iterables can be streamed to a file:

```php
(new FastExcel(new ArrayIterator($rows)))->export('file.xlsx');
```

A `Generator` is just one kind of `Traversable`, so the dispatch check and the constructor type hint now use `Traversable` (which already covers `Generator` and `Collection`).

### Tests
Adds `testExportFromTraversable`, exporting from an `ArrayIterator` and asserting the round-trip. Full suite green.

### Relationship to #343
Reworks @sshaik305's #343 (thanks!), which had the right idea but now conflicts with `master` and used a redundant `Generator|Traversable` union (`Generator` already implements `Traversable`). I'll close #343 in favour of this once it's merged.