### PR TITLE
Fail clearly when exporting multiple sheets to a single-sheet format (#244)

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -101,9 +101,19 @@ trait Exportable
     private function exportOrDownload($path, $function, ?callable $callback = null)
     {
         $writer = $this->makeWriter($path);
-        $writer->$function($path);
 
         $has_sheets = ($writer instanceof \OpenSpout\Writer\XLSX\Writer || $writer instanceof \OpenSpout\Writer\ODS\Writer);
+
+        // CSV (and any other single-sheet format) cannot hold multiple sheets.
+        // Fail with a clear message instead of a cryptic "undefined method
+        // ...::getCurrentSheet()" fatal further down.
+        if (!$has_sheets && $this->data instanceof SheetCollection && $this->data->count() > 1) {
+            throw new InvalidArgumentException(
+                'The "'.pathinfo($path, PATHINFO_EXTENSION).'" format does not support multiple sheets; use xlsx or ods.'
+            );
+        }
+
+        $writer->$function($path);
 
         // It can export one sheet (Collection) or N sheets (SheetCollection)
         $data = $this->transpose ? $this->transposeData() : ($this->data instanceof SheetCollection ? $this->data : collect([$this->data]));
@@ -118,7 +128,7 @@ trait Exportable
             } else {
                 throw new InvalidArgumentException('Unsupported type for $data');
             }
-            if (is_string($key)) {
+            if ($has_sheets && is_string($key)) {
                 $writer->getCurrentSheet()->setName($key);
             }
             if ($has_sheets && $data->keys()->last() !== $key) {

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -281,4 +281,42 @@ class IssuesTest extends TestCase
         unlink($odsUpload->getPathname());
         unlink($ods);
     }
+
+    /**
+     * Issue #244: exporting multiple sheets to a single-sheet format (CSV) must
+     * fail with a clear message instead of a cryptic
+     * "Call to undefined method ...\CSV\Writer::getCurrentSheet()" fatal.
+     */
+    public function testIssue244()
+    {
+        $sheets = new SheetCollection([
+            'articles' => collect([['col1' => 'a1', 'col2' => 'a2']]),
+            'blogs'    => collect([['col1' => 'b1', 'col2' => 'b2']]),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not support multiple sheets');
+
+        (new FastExcel($sheets))->export(__DIR__.'/issue_244.csv');
+    }
+
+    /**
+     * A single-sheet SheetCollection must still export fine to CSV (the sheet
+     * name is simply ignored, since CSV has no sheets).
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testIssue244SingleSheetCsv()
+    {
+        $sheets = new SheetCollection(['only' => $this->collection()]);
+
+        $file = __DIR__.'/issue_244_single.csv';
+        (new FastExcel($sheets))->export($file);
+
+        $this->assertEquals($this->collection(), (new FastExcel())->import($file));
+
+        unlink($file);
+    }
 }


### PR DESCRIPTION
### Problem
Exporting a `SheetCollection` with **multiple sheets to a CSV** crashed with a cryptic fatal:

```
Call to undefined method OpenSpout\Writer\CSV\Writer::getCurrentSheet()
```

CSV (and the writer) has no concept of sheets, but FastExcel still tried to name the current sheet. Reproduced on the current version (it's what #244 reports).

### Fix
- Throw a clear `InvalidArgumentException` **before the file is opened** when the data is a multi-sheet `SheetCollection` and the target format can't hold sheets:
  > `The "csv" format does not support multiple sheets; use xlsx or ods.`
- Guard the `getCurrentSheet()->setName()` call with `$has_sheets`, so a **single-sheet** `SheetCollection` still exports fine to CSV (the sheet name is simply ignored).

### Tests
- `testIssue244` — multi-sheet → CSV throws the clear exception.
- `testIssue244SingleSheetCsv` — single-sheet `SheetCollection` → CSV still round-trips.

Multi-sheet `.xlsx`/`.ods` export is unaffected. Fixes #244.