### PR TITLE
Make duplicate header columns unique on import (supersedes #312)

### DIFF
--- a/src/Importable.php
+++ b/src/Importable.php
@@ -324,7 +324,7 @@ trait Importable
             if ($k >= $this->start_row) {
                 if ($this->with_header) {
                     if ($k == $this->start_row) {
-                        $headers = $this->toStrings($row);
+                        $headers = $this->deduplicateHeaders($this->toStrings($row));
                         $count_header = count($headers);
                         continue;
                     }
@@ -369,5 +369,38 @@ trait Importable
         }
 
         return $values;
+    }
+
+    /**
+     * Make header names unique so array_combine() does not silently drop
+     * columns that share the same label. The first occurrence of a name is
+     * kept untouched (preserving backwards compatibility); every later
+     * duplicate gets a numeric suffix, e.g. "name", "name_2", "name_3".
+     *
+     * @param array $headers
+     *
+     * @return array
+     */
+    private function deduplicateHeaders($headers)
+    {
+        $seen = [];
+
+        foreach ($headers as &$header) {
+            $name = (string) $header;
+
+            if (!isset($seen[$name])) {
+                $seen[$name] = 1;
+                continue;
+            }
+
+            do {
+                $candidate = $name.'_'.(++$seen[$name]);
+            } while (isset($seen[$candidate]));
+
+            $seen[$candidate] = 1;
+            $header = $candidate;
+        }
+
+        return $headers;
     }
 }

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -169,6 +169,48 @@ class IssuesTest extends TestCase
         ]);
     }
 
+    /**
+     * PR #312: when the header row contains duplicate column names,
+     * array_combine() would silently collapse the repeated keys and lose
+     * data. Duplicate headers must be made unique so every column survives,
+     * while the first occurrence keeps its original name (backwards compat).
+     *
+     * @see https://github.com/rap2hpoutre/fast-excel/pull/312
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testIssue312()
+    {
+        $file = __DIR__.'/issue_312.csv';
+        file_put_contents($file, implode("\n", [
+            'name,name,name,email',
+            'John,Jonathan,Johnny,john@example.com',
+            'Jane,Janet,Janie,jane@example.com',
+        ])."\n");
+
+        $rows = (new FastExcel())->import($file);
+
+        // No column is dropped: all four values survive under unique keys,
+        // and the first "name" keeps its original (unsuffixed) label.
+        $this->assertEquals([
+            'name'   => 'John',
+            'name_2' => 'Jonathan',
+            'name_3' => 'Johnny',
+            'email'  => 'john@example.com',
+        ], $rows->first());
+
+        $this->assertEquals([
+            'name'   => 'Jane',
+            'name_2' => 'Janet',
+            'name_3' => 'Janie',
+            'email'  => 'jane@example.com',
+        ], $rows->last());
+
+        unlink($file);
+    }
+
     public function testIssue310()
     {
         $original_collection = $this->collection();


### PR DESCRIPTION
## What this does

When an imported sheet has two or more columns that share the same header name, `array_combine($headers, $row)` silently collapses the repeated keys, so the extra columns are dropped and their data is lost.

This makes header names unique before they're combined with each row:

- The **first** occurrence of a name keeps its original label (so existing imports that don't have duplicates — and the first column of those that do — are unaffected).
- Each later duplicate gets a numeric suffix: `name`, `name_2`, `name_3`, …

```
header row:  name | name | name | email
becomes:     name | name_2 | name_3 | email
```

So every column now survives the import instead of being silently overwritten.

## Credit

This builds directly on #312 by @muratcakmaksoftware, who first spotted and fixed the bug. I reworked the approach a little:

- the first column keeps its original name (the original patch suffixed every duplicate, including the first, so `name` was lost entirely);
- it guards against a suffixed name colliding with an existing column (e.g. `name, name, name_2`);
- the logic lives in its own `deduplicateHeaders()` helper rather than inside `toStrings()`.

Since #312 is from 2023 and predates the OpenSpout 4 / current test setup, this also adds the regression test it was missing.

Closes #312.

## Test

`testIssue312` imports a CSV with three `name` columns plus an `email` column and asserts all four values survive under unique keys. Full suite is green locally.
