### PR TITLE
Make string vs number export configurable (#193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,30 @@ return (new FastExcel($list))
     ->download('file.xlsx');
 ```
 
+### Export values as strings or numbers
+
+By default numbers are written as numbers and strings as strings. Use
+`stringValues()` to force every value to a text cell — handy to keep leading
+zeros or long numeric IDs (e.g. phone numbers) intact:
+
+```php
+// 0660123456 stays "0660123456" instead of becoming 660123456
+(new FastExcel($users))->stringValues()->export('users.xlsx');
+```
+
+Need finer control? `setColumnFormat()` overrides the type per column and takes
+precedence over `stringValues()`:
+
+```php
+(new FastExcel($users))
+    ->stringValues()                                  // text by default
+    ->setColumnFormat([
+        'id'    => 'number',                          // keep as number
+        'phone' => 'string',                          // keep as text
+    ])
+    ->export('users.xlsx');
+```
+
 ## Why?
 
 FastExcel is intended at being Laravel-flavoured [Spout](https://github.com/box/spout):

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -31,6 +31,12 @@ trait Exportable
     /** @var Style[] */
     private $column_styles = [];
 
+    /** @var bool */
+    private $string_values = false;
+
+    /** @var array<string, string> */
+    private $column_formats = [];
+
     /**
      * @param AbstractOptions $options
      *
@@ -42,6 +48,36 @@ trait Exportable
     public function setColumnStyles($styles): static
     {
         $this->column_styles = $styles;
+
+        return $this;
+    }
+
+    /**
+     * Export every scalar value as a string (text cell). Useful to preserve
+     * leading zeros or long numeric IDs (e.g. phone numbers) that would
+     * otherwise be written as numbers. Per-column setColumnFormat() rules take
+     * precedence over this flag.
+     *
+     * @param bool $enabled
+     */
+    public function stringValues(bool $enabled = true): static
+    {
+        $this->string_values = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * Force the cell type for specific columns, keyed by column name, e.g.
+     * ['phone' => 'string', 'price' => 'number']. A 'string' column is written
+     * as text; a 'number' column casts numeric strings back to int/float. These
+     * rules win over stringValues().
+     *
+     * @param array<string, string> $formats
+     */
+    public function setColumnFormat(array $formats): static
+    {
+        $this->column_formats = $formats;
 
         return $this;
     }
@@ -304,7 +340,7 @@ trait Exportable
                 $need_conversion = true;
             }
         }
-        if ($need_conversion) {
+        if ($need_conversion || $this->string_values || count($this->column_formats)) {
             $this->transform($collection);
         }
     }
@@ -324,11 +360,40 @@ trait Exportable
      */
     private function transformRow($data)
     {
-        return collect($data)->map(function ($value) {
-            return is_null($value) ? (string) $value : $value;
+        return collect($data)->map(function ($value, $key) {
+            if (is_null($value)) {
+                return (string) $value;
+            }
+
+            return $this->formatValue($value, $key);
         })->filter(function ($value) {
             return is_string($value) || is_int($value) || is_float($value) || $value instanceof DateTimeInterface;
         });
+    }
+
+    /**
+     * Apply the configured export format to a single value. A per-column rule
+     * (setColumnFormat) wins over the global stringValues() flag. Dates and
+     * non-numeric strings are always left untouched.
+     *
+     * @param mixed      $value
+     * @param int|string $key
+     *
+     * @return mixed
+     */
+    private function formatValue($value, $key)
+    {
+        $format = $this->column_formats[$key] ?? ($this->string_values ? 'string' : null);
+
+        if ($format === 'string' && (is_int($value) || is_float($value))) {
+            return (string) $value;
+        }
+
+        if ($format === 'number' && is_string($value) && is_numeric($value)) {
+            return $value + 0;
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -337,4 +337,48 @@ class IssuesTest extends TestCase
 
         unlink($file);
     }
+
+    /**
+     * Issue #193: the string-vs-number cell type on export must be configurable.
+     * By default numbers stay numeric; stringValues() forces every scalar to a
+     * text cell (preserving leading zeros / long IDs); setColumnFormat() lets
+     * each column opt in or out and takes precedence over stringValues().
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     */
+    public function testIssue193()
+    {
+        $file = __DIR__.'/issue_193.xlsx';
+        $row = ['id' => 7, 'phone' => '0660123', 'price' => 12.5];
+
+        // Default: numbers stay numeric, strings stay strings (leading zero kept).
+        (new FastExcel(collect([$row])))->export($file);
+        $default = (new FastExcel())->import($file)->first();
+        $this->assertSame(7, $default['id']);
+        $this->assertSame('0660123', $default['phone']);
+        $this->assertSame(12.5, $default['price']);
+
+        // stringValues(): every scalar becomes a text cell.
+        (new FastExcel(collect([$row])))->stringValues()->export($file);
+        $strings = (new FastExcel())->import($file)->first();
+        $this->assertSame('7', $strings['id']);
+        $this->assertSame('0660123', $strings['phone']);
+        $this->assertSame('12.5', $strings['price']);
+
+        // setColumnFormat() overrides per column (and wins over stringValues()).
+        (new FastExcel(collect([$row])))
+            ->stringValues()
+            ->setColumnFormat(['phone' => 'number', 'price' => 'number'])
+            ->export($file);
+        $mixed = (new FastExcel())->import($file)->first();
+        $this->assertSame('7', $mixed['id']);          // still string (global flag)
+        $this->assertSame(660123, $mixed['phone']);    // forced numeric
+        $this->assertSame(12.5, $mixed['price']);      // forced numeric
+
+        unlink($file);
+    }
 }


### PR DESCRIPTION
Closes #193.

### Background
#193 asks for an easy, explicit way to control whether values are exported as **numbers** or as **text**. Today numbers already export as numbers by default (since #166, which resolved #176 and #183), but there's **no supported way to force text output** — which is what users in #188 need to keep leading zeros and long numeric IDs (phone numbers, etc.) intact.

### What this adds
Two opt-in exporter methods. Default behavior is unchanged.

```php
// Force every value to a text cell (keeps leading zeros / long IDs)
(new FastExcel($users))->stringValues()->export('users.xlsx');

// Per-column override, wins over stringValues()
(new FastExcel($users))
    ->stringValues()
    ->setColumnFormat([
        'id'    => 'number',   // keep numeric
        'phone' => 'string',   // keep text
    ])
    ->export('users.xlsx');
```

Behavior (verified via XLSX round-trip):

| Mode | `id` (7) | `phone` ("0660123") | `price` (12.5) |
| --- | --- | --- | --- |
| default | `7` (number) | `"0660123"` (text) | `12.5` (number) |
| `stringValues()` | `"7"` | `"0660123"` | `"12.5"` |
| `stringValues()` + `setColumnFormat(['phone'=>'number','price'=>'number'])` | `"7"` | `660123` | `12.5` |

### Implementation
- `string_values` flag + `column_formats` map on the `Exportable` trait.
- Both routed through a single `formatValue()` helper in `transformRow()`, so the collection and generator export paths share one code path.
- `'string'` casts int/float to string; `'number'` casts numeric strings back to int/float. Dates and non-numeric strings are always left untouched.

### Tests
- `testIssue193` covers all three modes with strict `assertSame` type checks.
- Full suite green locally (33 tests); README documents both methods.

### Note for the maintainer
#193 was opened as a broad WIP. This is intentionally a minimal, backward-compatible first step focused on the recurring string/number requests (#166, #176, #183, #188). Happy to adjust the API naming or extend it (e.g. number formats / masks) based on your preference.
