### PR TITLE
fix: write placeholder row for empty sheets in multi-sheet exports

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -211,6 +211,15 @@ trait Exportable
                 return $callback($value);
             });
         }
+
+        if ($collection->isEmpty()) {
+            if ($this->data instanceof SheetCollection) {
+                $this->writePlaceholderRowForEmptySheet($writer);
+            }
+
+            return;
+        }
+
         // Prepare collection (i.e remove non-string)
         $this->prepareCollection($collection);
         // Add header row.
@@ -248,7 +257,10 @@ trait Exportable
 
     private function writeRowsFromGenerator($writer, Generator $generator, ?callable $callback = null)
     {
+        $hasRows = false;
+
         foreach ($generator as $key => $item) {
+            $hasRows = true;
             // Apply callback
             if ($callback) {
                 $item = $callback($item);
@@ -264,11 +276,23 @@ trait Exportable
             // Write rows (one by one).
             $writer->addRow($this->createRow($item->toArray(), $this->rows_style, $this->column_styles));
         }
+
+        if (!$hasRows && $this->data instanceof SheetCollection) {
+            $this->writePlaceholderRowForEmptySheet($writer);
+        }
     }
 
     private function writeRowsFromArray($writer, array $array, ?callable $callback = null)
     {
         $collection = collect($array);
+
+        if ($collection->isEmpty()) {
+            if ($this->data instanceof SheetCollection) {
+                $this->writePlaceholderRowForEmptySheet($writer);
+            }
+
+            return;
+        }
 
         if (is_object($collection->first()) || is_array($collection->first())) {
             // provided $array was valid and could be converted to a collection
@@ -353,6 +377,22 @@ trait Exportable
         $this->rows_style = $style;
 
         return $this;
+    }
+
+    /**
+     * OpenSpout multi-sheet workbooks require at least one non-empty row per worksheet.
+     * Empty rows are skipped by the XLSX writer and would otherwise produce a corrupt file.
+     *
+     * @param \OpenSpout\Writer\WriterInterface $writer
+     */
+    private function writePlaceholderRowForEmptySheet($writer): void
+    {
+        if (!$writer instanceof \OpenSpout\Writer\XLSX\Writer && !$writer instanceof \OpenSpout\Writer\ODS\Writer) {
+            return;
+        }
+
+        // OpenSpout treats '' as an empty cell and does not write row XML for empty rows.
+        $writer->addRow(Row::fromValues([' ']));
     }
 
     /**

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -391,8 +391,7 @@ trait Exportable
             return;
         }
 
-        // OpenSpout treats '' as an empty cell and does not write row XML for empty rows.
-        $writer->addRow(Row::fromValues([' ']));
+        $writer->addRow($this->createRow([' ']));
     }
 
     /**

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -363,7 +363,7 @@ class IssuesTest extends TestCase
         foreach ($reader->getSheetIterator() as $sheet) {
             $rowCount = 0;
             foreach ($sheet->getRowIterator() as $row) {
-                ++$rowCount;
+                $rowCount++;
             }
             $sheets[$sheet->getName()] = $rowCount;
         }

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -337,4 +337,44 @@ class IssuesTest extends TestCase
 
         unlink($file);
     }
+
+    /**
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     *
+     * @see https://github.com/rap2hpoutre/fast-excel/issues/372
+     */
+    public function testIssue372()
+    {
+        $file = __DIR__.'/issue372.xlsx';
+
+        (new FastExcel(new SheetCollection([
+            'A' => collect([['a' => 'b']]),
+            'B' => collect(),
+        ])))->export($file);
+
+        $reader = new \OpenSpout\Reader\XLSX\Reader(new \OpenSpout\Reader\XLSX\Options());
+        $reader->open($file);
+
+        $sheets = [];
+        foreach ($reader->getSheetIterator() as $sheet) {
+            $rowCount = 0;
+            foreach ($sheet->getRowIterator() as $row) {
+                ++$rowCount;
+            }
+            $sheets[$sheet->getName()] = $rowCount;
+        }
+
+        $reader->close();
+
+        $this->assertArrayHasKey('A', $sheets);
+        $this->assertArrayHasKey('B', $sheets);
+        $this->assertSame(2, $sheets['A']);
+        $this->assertSame(1, $sheets['B']);
+
+        unlink($file);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #372.

Exporting a `SheetCollection` where one or more sheets are empty (e.g. `collect()` or `[]`) produced an invalid XLSX file. OpenSpout skips rows with no cell data, so empty worksheets ended up with no `<row>` elements in `sheetData` and malformed dimension metadata (e.g. `ref="A1:@0"`), which Excel treats as corrupt.

This PR writes a single-space placeholder row for empty sheets in multi-sheet XLSX/ODS exports via a new `writePlaceholderRowForEmptySheet()` helper. The placeholder is only applied when exporting a `SheetCollection` — single-sheet exports are unchanged.

**Changes:**
- `src/Exportable.php` — handle empty collections, arrays, and generators in multi-sheet exports
- `tests/IssuesTest.php` — add `testIssue372` regression test

## Test plan

- [x] `vendor/bin/phpunit --filter testIssue372 tests/IssuesTest.php`
- [x] `vendor/bin/phpunit` (full suite passes)
- [x] Reproduce issue scenario manually:

```php
(new FastExcel(new SheetCollection([
    'A' => collect([['a' => 'b']]),
    'B' => collect(),
])))->export('file.xlsx');
```

- [x] Confirm sheet B has 1 row and `xl/worksheets/sheet2.xml` contains a valid `<row>` element with `dimension ref="A1:A1"`