### PR TITLE
test: cover multi-sheet export with a Traversable per sheet (#252)

### DIFF
--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -459,4 +459,58 @@ class IssuesTest extends TestCase
 
         unlink($file);
     }
+
+    /**
+     * Issue #252: exporting multiple sheets where each sheet is a Generator (or
+     * any other Traversable, not only a Collection). Each sheet value goes
+     * through the same Traversable dispatch as a single-sheet export, so headers
+     * and rows are written per sheet.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     *
+     * @see https://github.com/rap2hpoutre/fast-excel/issues/252
+     */
+    public function testIssue252()
+    {
+        $file = __DIR__.'/issue252.xlsx';
+
+        $generator = function () {
+            yield ['name' => 'Alice', 'age' => 30];
+            yield ['name' => 'Bob', 'age' => 25];
+        };
+
+        (new FastExcel(new SheetCollection([
+            'People'  => $generator(),                                   // Generator sheet
+            'Numbers' => new \ArrayIterator([['n' => 1], ['n' => 2]]),   // non-Generator Traversable
+        ])))->export($file);
+
+        $reader = new \OpenSpout\Reader\XLSX\Reader(new \OpenSpout\Reader\XLSX\Options());
+        $reader->open($file);
+
+        $sheets = [];
+        foreach ($reader->getSheetIterator() as $sheet) {
+            $rows = [];
+            foreach ($sheet->getRowIterator() as $row) {
+                $rows[] = array_map(fn ($cell) => $cell->getValue(), $row->getCells());
+            }
+            $sheets[$sheet->getName()] = $rows;
+        }
+
+        $reader->close();
+
+        // Both Traversable sheets are written with a header row + their data.
+        $this->assertSame(['name', 'age'], $sheets['People'][0]);
+        $this->assertSame('Alice', $sheets['People'][1][0]);
+        $this->assertSame('Bob', $sheets['People'][2][0]);
+        $this->assertCount(3, $sheets['People']);
+
+        $this->assertSame(['n'], $sheets['Numbers'][0]);
+        $this->assertCount(3, $sheets['Numbers']);
+
+        unlink($file);
+    }
 }


### PR DESCRIPTION
### What

Adds a regression test (`testIssue252`) for exporting a `SheetCollection` whose sheet values are **Generators** (or any other `Traversable`, e.g. an `Iterator`) rather than `Collection`s.

### Why

#397 broadened the per-sheet dispatch in `Exportable::exportOrDownload()` from `instanceof Generator` to `instanceof Traversable`, and `writeRowsFromGenerator()` now type-hints `Traversable`. As a result, each value of a `SheetCollection` goes through the same Traversable path as a single-sheet export — so per-sheet generators already work, including the header row. This was the question raised in #252, but it had no test guarding it.

### Test

`testIssue252` exports a `SheetCollection` mixing a `Generator` sheet and an `ArrayIterator` sheet, then reads the file back and asserts each sheet has its header row + data. Full suite green (38 tests).

```php
$generator = function () {
    yield ['name' => 'Alice', 'age' => 30];
    yield ['name' => 'Bob', 'age' => 25];
};

(new FastExcel(new SheetCollection([
    'People'  => $generator(),
    'Numbers' => new ArrayIterator([['n' => 1], ['n' => 2]]),
])))->export('file.xlsx');
```

Closes #252.