### PR TITLE
feat: style header columns individually (setHeaderColumnStyles) (#367)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,22 @@ return (new FastExcel($list))
     ->download('file.xlsx');
 ```
 
+You can also style each header column individually with `setHeaderColumnStyles`
+(the header-row counterpart of `setColumnStyles`). Keys are the zero-based
+column positions:
+
+```php
+use OpenSpout\Common\Entity\Style\Color;
+use OpenSpout\Common\Entity\Style\Style;
+
+return (new FastExcel($list))
+    ->setHeaderColumnStyles([
+        0 => (new Style())->setBackgroundColor(Color::YELLOW),
+        1 => (new Style())->setFontColor(Color::BLUE),
+    ])
+    ->download('file.xlsx');
+```
+
 ### Export values as strings or numbers
 
 By default numbers are written as numbers and strings as strings. Use

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -30,6 +30,8 @@ trait Exportable
 
     /** @var Style[] */
     private $header_column_styles = [];
+
+    /** @var Style[] */
     private $column_styles = [];
 
     /** @var bool */

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -29,6 +29,7 @@ trait Exportable
     private $rows_style;
 
     /** @var Style[] */
+    private $header_column_styles = [];
     private $column_styles = [];
 
     /** @var bool */
@@ -43,6 +44,14 @@ trait Exportable
      * @return mixed
      */
     abstract protected function setOptions(&$options);
+
+    /** @param Style[] $styles */
+    public function setHeaderColumnStyles($styles): static
+    {
+        $this->header_column_styles = $styles;
+
+        return $this;
+    }
 
     /** @param Style[] $styles */
     public function setColumnStyles($styles): static
@@ -353,8 +362,8 @@ trait Exportable
         }
 
         $keys = array_keys(is_array($first_row) ? $first_row : $first_row->toArray());
-        $writer->addRow($this->createRow($keys, $this->header_style));
-//        $writer->addRow(WriterEntityFactory::createRowFromArray($keys, $this->header_style));
+        $writer->addRow($this->createRow($keys, $this->header_style, $this->header_column_styles));
+        //        $writer->addRow(WriterEntityFactory::createRowFromArray($keys, $this->header_style));
     }
 
     /**

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -269,6 +269,35 @@ class FastExcelTest extends TestCase
     }
 
     /**
+     * Issue #367: each header column can be styled individually via
+     * setHeaderColumnStyles(), the header-row counterpart of setColumnStyles().
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     */
+    public function testExportWithHeaderColumnStyles()
+    {
+        $original_collection = $this->collection();
+
+        $file = __DIR__.'/test-header-column-styles.xlsx';
+        (new FastExcel(clone $original_collection))
+            ->setHeaderColumnStyles([
+                0 => (new Style())->setBackgroundColor(Color::YELLOW),
+                1 => (new Style())->setFontColor(Color::BLUE),
+            ])
+            ->export($file);
+
+        // The reader does not expose cell styles, so assert the styled export
+        // still round-trips the data (same approach as the other style tests).
+        $this->assertEquals($original_collection, (new FastExcel())->import($file));
+
+        unlink($file);
+    }
+
+    /**
      * @throws \OpenSpout\Common\Exception\IOException
      * @throws \OpenSpout\Common\Exception\InvalidArgumentException
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException


### PR DESCRIPTION
### What

Adds `setHeaderColumnStyles()` — the header-row counterpart of `setColumnStyles()` — so each **header** column can be styled individually (background, font color, etc.):

```php
use OpenSpout\Common\Entity\Style\Color;
use OpenSpout\Common\Entity\Style\Style;

(new FastExcel($list))
    ->setHeaderColumnStyles([
        0 => (new Style())->setBackgroundColor(Color::YELLOW),
        1 => (new Style())->setFontColor(Color::BLUE),
    ])
    ->download('file.xlsx');
```

### Why

Requested in #367. There was already per-column styling for data rows (`setColumnStyles()`) but no equivalent for the header row. `createRow()` already accepts a per-column `$styles` array (passed to `Row::fromValuesWithStyles`), so this just wires a new `$header_column_styles` array into `writeHeader()`.

### Credit

Builds directly on @BAY-EAXQX's #368 — the feature commit is preserved with original authorship. This PR continues it by adding what was missing for merge:
- `testExportWithHeaderColumnStyles` (round-trips a per-column-styled header; mirrors the existing style smoke tests since the reader doesn't expose cell styles)
- README example under the styling section
- gave `$header_column_styles` and `$column_styles` their own `@var Style[]` docblocks

### Tests

Full suite green — 39 tests, 88 assertions.

Closes #367. Supersedes #368.