### PR TITLE
feat: add importLazy() for memory-efficient streaming imports (#374)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,25 @@ Reading speed is the same either way — it is dominated by the underlying
 returned. The difference above is memory, which is what lets very large files finish
 at all.
 
+If you would rather keep working with the rows than process them inside a callback,
+`importLazy` returns a [`LazyCollection`](https://laravel.com/docs/collections#lazy-collections)
+that streams rows one at a time — you get the full Collection API while memory stays
+flat:
+
+```php
+use Illuminate\Support\LazyCollection;
+
+(new FastExcel)->importLazy('file.xlsx')
+    ->chunk(1000)
+    ->each(function (LazyCollection $chunk) {
+        User::insert($chunk->all());
+    });
+```
+
+`importLazy` accepts the same optional callback as `import`, and honors `sheet()`,
+`withoutHeaders()`, and header de-duplication. Transposing (`transpose()`) is not
+supported with lazy import.
+
 ### Add header and rows style
 
 Add header and rows style with `headerStyle` and `rowsStyle` methods.

--- a/src/Importable.php
+++ b/src/Importable.php
@@ -3,6 +3,7 @@
 namespace Rap2hpoutre\FastExcel;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Reader\SheetInterface;
 use OpenSpout\Writer\Common\AbstractOptions;
@@ -51,6 +52,42 @@ trait Importable
         $reader->close();
 
         return collect($collection ?? []);
+    }
+
+    /**
+     * Import file lazily using LazyCollection for memory efficiency.
+     *
+     * @param string|\Symfony\Component\HttpFoundation\File\UploadedFile $path
+     * @param callable|null                                              $callback
+     *
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Common\Exception\IOException
+     *
+     * @return LazyCollection
+     */
+    public function importLazy($path, ?callable $callback = null)
+    {
+        return new LazyCollection(function () use ($path, $callback) {
+            $reader = $this->reader($path);
+
+            try {
+                foreach ($reader->getSheetIterator() as $key => $sheet) {
+                    if ($this->sheet_number != $key) {
+                        continue;
+                    }
+                    if ($this->transpose) {
+                        // Fallback to non-lazy processing when transposing
+                        throw new \Exception('Transposing is not supported with lazy import.');
+                    }
+
+                    yield from $this->importSheetGenerator($sheet, $callback);
+                    break;
+                }
+            } finally {
+                $reader->close();
+            }
+        });
     }
 
     /**
@@ -302,6 +339,44 @@ trait Importable
     }
 
     /**
+     * Normalize a row according to start_row and headers.
+     * - Updates $headers and $count_header when encountering header row.
+     * - Pads/truncates rows to header size when headers exist.
+     * - Returns combined associative row when headers exist, or the raw row when not.
+     * - Returns null to skip processing (before start_row or header row itself).
+     *
+     * @param int   $key
+     * @param array $row
+     * @param array $headers
+     * @param int   $count_header
+     *
+     * @return array|null
+     */
+    private function normalizeRow(int $key, array $row, array &$headers, int &$count_header): ?array
+    {
+        if ($key < $this->start_row) {
+            return null;
+        }
+
+        if ($this->with_header) {
+            if ($key == $this->start_row) {
+                $headers = $this->uniqueHeaders($this->toStrings($row));
+                $count_header = count($headers);
+
+                return null; // skip header row
+            }
+
+            if ($count_header > $count_row = count($row)) {
+                $row = array_merge($row, array_fill(0, $count_header - $count_row, null));
+            } elseif ($count_header < $count_row = count($row)) {
+                $row = array_slice($row, 0, $count_header);
+            }
+        }
+
+        return empty($headers) ? $row : array_combine($headers, $row);
+    }
+
+    /**
      * @param SheetInterface $sheet
      * @param callable|null  $callback
      *
@@ -313,7 +388,7 @@ trait Importable
         $collection = [];
         $count_header = 0;
 
-        foreach ($sheet->getRowIterator() as $k => $rowAsObject) {
+        foreach ($sheet->getRowIterator() as $key => $rowAsObject) {
             $row = array_map(function (Cell $cell) {
                 return match (true) {
                     $cell instanceof Cell\FormulaCell => $cell->getComputedValue(),
@@ -321,26 +396,17 @@ trait Importable
                 };
             }, $rowAsObject->getCells());
 
-            if ($k >= $this->start_row) {
-                if ($this->with_header) {
-                    if ($k == $this->start_row) {
-                        $headers = $this->uniqueHeaders($this->toStrings($row));
-                        $count_header = count($headers);
-                        continue;
-                    }
-                    if ($count_header > $count_row = count($row)) {
-                        $row = array_merge($row, array_fill(0, $count_header - $count_row, null));
-                    } elseif ($count_header < $count_row = count($row)) {
-                        $row = array_slice($row, 0, $count_header);
-                    }
+            $current = $this->normalizeRow($key, $row, $headers, $count_header);
+            if ($current === null) {
+                continue;
+            }
+
+            if ($callback) {
+                if ($result = $callback($current)) {
+                    $collection[] = $result;
                 }
-                if ($callback) {
-                    if ($result = $callback(empty($headers) ? $row : array_combine($headers, $row))) {
-                        $collection[] = $result;
-                    }
-                } else {
-                    $collection[] = empty($headers) ? $row : array_combine($headers, $row);
-                }
+            } else {
+                $collection[] = $current;
             }
         }
 
@@ -349,6 +415,43 @@ trait Importable
         }
 
         return $collection;
+    }
+
+    /**
+     * Create a generator that lazily yields imported rows from a sheet.
+     *
+     * @param SheetInterface $sheet
+     * @param callable|null  $callback
+     *
+     * @return \Generator
+     */
+    private function importSheetGenerator(SheetInterface $sheet, ?callable $callback = null): \Generator
+    {
+        $headers = [];
+        $count_header = 0;
+
+        foreach ($sheet->getRowIterator() as $key => $rowAsObject) {
+            $row = array_map(function (Cell $cell) {
+                return match (true) {
+                    $cell instanceof Cell\FormulaCell => $cell->getComputedValue(),
+                    default                           => $cell->getValue(),
+                };
+            }, $rowAsObject->getCells());
+
+            $current = $this->normalizeRow($key, $row, $headers, $count_header);
+            if ($current === null) {
+                continue;
+            }
+
+            if ($callback) {
+                $result = $callback($current);
+                if ($result) {
+                    yield $result;
+                }
+            } else {
+                yield $current;
+            }
+        }
     }
 
     /**

--- a/tests/LazyImportTest.php
+++ b/tests/LazyImportTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Rap2hpoutre\FastExcel\Tests;
+
+use Illuminate\Support\LazyCollection;
+use Rap2hpoutre\FastExcel\FastExcel;
+
+class LazyImportTest extends TestCase
+{
+    /**
+     * Ensure importLazy returns a LazyCollection and yields same data as import.
+     */
+    public function testImportLazyXlsx()
+    {
+        $fe = new FastExcel();
+        $lazy = $fe->importLazy(__DIR__.'/test1.xlsx');
+        $this->assertInstanceOf(LazyCollection::class, $lazy);
+        // Materialize to compare with existing helper collection()
+        $this->assertEquals($this->collection(), $lazy->collect());
+    }
+
+    /**
+     * Ensure importLazy supports callback mapping similar to import.
+     */
+    public function testImportLazyWithCallback()
+    {
+        $fe = new FastExcel();
+        $lazy = $fe->importLazy(__DIR__.'/test1.xlsx', function ($row) {
+            return [
+                'col1' => $row['col1'],
+                'col2' => $row['col2'],
+            ];
+        });
+
+        $expected = (new FastExcel())->import(__DIR__.'/test1.xlsx', function ($row) {
+            return [
+                'col1' => $row['col1'],
+                'col2' => $row['col2'],
+            ];
+        });
+
+        $this->assertEquals($expected, $lazy->collect());
+    }
+
+    /**
+     * The lazy path shares normalizeRow() with the eager import, so it must also
+     * de-duplicate headers (#312/#259): duplicates get a numeric suffix and empty
+     * headers a positional name, instead of colliding in array_combine().
+     */
+    public function testImportLazyDeduplicatesHeaders()
+    {
+        $file = __DIR__.'/lazy_dup_headers.csv';
+        file_put_contents($file, "Name,Name,,Age\nJoe,Smith,x,30\nJane,Doe,y,25\n");
+
+        $rows = (new FastExcel())->importLazy($file)->collect();
+
+        $first = $rows->first();
+        $this->assertSame(['Name', 'Name_2', 'column_3', 'Age'], array_keys($first));
+        $this->assertSame('Joe', $first['Name']);
+        $this->assertSame('Smith', $first['Name_2']);   // would have been lost before
+        $this->assertSame('x', $first['column_3']);
+        $this->assertSame('30', $first['Age']);
+        $this->assertCount(2, $rows);
+
+        unlink($file);
+    }
+}


### PR DESCRIPTION
### What

Adds `importLazy()` — returns a Laravel [`LazyCollection`](https://laravel.com/docs/collections#lazy-collections) that streams rows one at a time, so you keep the full Collection API while memory stays flat. An ergonomic alternative to the existing return-`null` callback pattern for very large files.

```php
use Illuminate\Support\LazyCollection;

(new FastExcel)->importLazy('file.xlsx')
    ->chunk(1000)
    ->each(fn (LazyCollection $chunk) => User::insert($chunk->all()));
```

### How

The per-row normalization (`start_row`, header sizing, `array_combine`) is extracted into a shared `normalizeRow()` helper used by both the eager `importSheet()` and the new `importSheetGenerator()`. No behavior change to `import()`; the lazy path reuses the exact same normalization. Transposing is unsupported when importing lazily (throws).

### Credit

Continues @cwilsn's #374 (preserving original authorship on the commit). The PR had drifted from `master`; this rebases it and resolves the conflicts:

- **Preserves header de-duplication (#312/#259):** master's `uniqueHeaders()` is applied inside the shared `normalizeRow()`, so the lazy path de-dups headers too (the original PR predated that fix and would have regressed it).
- **Preserves `UploadedFile` path support** added to the import docblocks since.
- Dropped an unused `Illuminate\Support\Str` import.
- Added a **README** section under "Import large files (low memory)".
- Added a **regression test** (`testImportLazyDeduplicatesHeaders`) proving the lazy path de-dups headers, plus the author's original `importLazy` tests.

### Tests

Full suite green — 42 tests, 97 assertions.

Closes #374.