### PR TITLE
feat: add withSheetContext() to pass sheet name to importSheets callback (#369)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,22 @@ Import multiple sheets with sheets names:
 $sheets = (new FastExcel)->withSheetsNames()->importSheets('file.xlsx');
 ```
 
+Use `withSheetContext()` to receive the current sheet name as the first argument
+of the `importSheets` callback — handy when the same field names need to be
+handled differently per sheet:
+
+```php
+$sheets = (new FastExcel)
+    ->withSheetContext()
+    ->importSheets('file.xlsx', function ($sheetName, $row) {
+        if ($sheetName === 'Users' && empty($row['email'])) {
+            return null; // skip rows without an email on the Users sheet
+        }
+
+        return $row + ['_sheet' => $sheetName];
+    });
+```
+
 ### Export large collections with chunk
 
 Export rows one by one to avoid `memory_limit` issues [using `yield`](https://www.php.net/manual/en/language.generators.syntax.php):

--- a/src/Facades/FastExcel.php
+++ b/src/Facades/FastExcel.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureReaderUsing(?callable $callback = null)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureWriterUsing(?callable $callback = null)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureOptionsUsing(?callable $callback = null)
+ * @method static \Rap2hpoutre\FastExcel\FastExcel withSheetContext()
  *
  * @see \Rap2hpoutre\FastExcel\FastExcel
  */

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -118,6 +118,18 @@ class FastExcel
     }
 
     /**
+     * Enable passing sheet name to callback.
+     *
+     * @return $this
+     */
+    public function withSheetContext()
+    {
+        $this->with_sheet_context = true;
+
+        return $this;
+    }
+
+    /**
      * @return $this
      */
     public function startRow(int $row)

--- a/src/Importable.php
+++ b/src/Importable.php
@@ -23,6 +23,11 @@ trait Importable
     private $sheet_number = 1;
 
     /**
+     * @var bool
+     */
+    private $with_sheet_context = false;
+
+    /**
      * @param AbstractOptions $options
      *
      * @return mixed
@@ -379,6 +384,7 @@ trait Importable
         $headers = [];
         $collection = [];
         $count_header = 0;
+        $sheetName = $sheet->getName();
 
         foreach ($sheet->getRowIterator() as $key => $rowAsObject) {
             $row = array_map(function (Cell $cell) {
@@ -394,7 +400,8 @@ trait Importable
             }
 
             if ($callback) {
-                if ($result = $callback($current)) {
+                $result = $this->with_sheet_context ? $callback($sheetName, $current) : $callback($current);
+                if ($result) {
                     $collection[] = $result;
                 }
             } else {

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -278,6 +278,46 @@ class FastExcelTest extends TestCase
     }
 
     /**
+     * Issue #366: withSheetContext() makes the importSheets callback receive the
+     * current sheet name as its first argument, so the same field names can be
+     * handled differently per sheet.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     */
+    public function testImportSheetsWithSheetContext()
+    {
+        $collections = [
+            'Users'    => collect([['name' => 'Jane'], ['name' => 'John']]),
+            'Projects' => collect([['name' => 'Alpha']]),
+        ];
+        $file = __DIR__.'/test_sheet_context.xlsx';
+        (new FastExcel(new SheetCollection($collections)))->export($file);
+
+        $seenSheets = [];
+        $sheets = (new FastExcel())
+            ->withSheetsNames()
+            ->withSheetContext()
+            ->importSheets($file, function ($sheetName, $row) use (&$seenSheets) {
+                $seenSheets[] = $sheetName;
+
+                // Tag each row with the sheet it came from.
+                return $row + ['_sheet' => $sheetName];
+            });
+
+        // The callback received the sheet name for every row.
+        $this->assertSame(['Users', 'Users', 'Projects'], $seenSheets);
+        $this->assertSame('Users', $sheets->get('Users')[0]['_sheet']);
+        $this->assertSame('Jane', $sheets->get('Users')[0]['name']);
+        $this->assertSame('Projects', $sheets->get('Projects')[0]['_sheet']);
+
+        unlink($file);
+    }
+
+    /**
      * @throws \OpenSpout\Common\Exception\IOException
      * @throws \OpenSpout\Common\Exception\InvalidArgumentException
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException


### PR DESCRIPTION
### What

Adds an opt-in `withSheetContext()` so the `importSheets` callback receives the current **sheet name** as its first argument:

```php
$sheets = (new FastExcel)
    ->withSheetContext()
    ->importSheets('file.xlsx', function ($sheetName, $row) {
        if ($sheetName === 'Users' && empty($row['email'])) {
            return null; // skip rows without an email on the Users sheet
        }

        return $row + ['_sheet' => $sheetName];
    });
```

Useful when the same field names appear across different sheets and need per-sheet handling.

### Backwards compatible

Fully opt-in. Without `withSheetContext()`, the callback still receives a single `$row` argument exactly as before.

### Credit

Continues @StarkOne's #369 (original authorship preserved on the commit). The branch had drifted from `master`; this rebases it and keeps what landed since:

- **Header de-duplication (#312/#259):** master's `uniqueHeaders()` is retained alongside the new sheet-context branch in `importSheet()`.
- **`configureOptionsUsing` facade hint** kept in the `@method` list.
- Added a **README** example under "Import multiple sheets".
- Added a **regression test** (`testImportSheetsWithSheetContext`) asserting the sheet name reaches the callback for every row across two named sheets.

### Tests

Full suite green — 40 tests, 92 assertions.

Closes #369. Resolves #366.