### PR TITLE
ci: benchmark PRs against base (time + peak memory)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,57 @@
+name: Benchmark
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip
+          coverage: none
+
+      - name: Install dependencies
+        uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: "--prefer-dist --no-cache"
+
+      - name: Check bench script exists
+        id: bench
+        run: echo "exists=$([ -f bench/bench.php ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Benchmark PR head
+        if: steps.bench.outputs.exists == 'true'
+        run: php bench/bench.php 30000 5 --json | tee /tmp/head.json
+
+      - name: Benchmark base branch
+        if: github.event_name == 'pull_request' && steps.bench.outputs.exists == 'true'
+        run: |
+          # Keep vendor/ and the bench script from the PR head; only swap the
+          # library code, so both sides run under identical dependencies.
+          cp bench/bench.php /tmp/bench.php
+          git checkout ${{ github.event.pull_request.base.sha }} -- src/
+          php /tmp/bench.php 30000 5 --json | tee /tmp/base.json
+
+      - name: Compare
+        if: github.event_name == 'pull_request' && steps.bench.outputs.exists == 'true'
+        run: php /tmp/bench.php --compare /tmp/base.json /tmp/head.json | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Single-run summary
+        if: github.event_name != 'pull_request' && steps.bench.outputs.exists == 'true'
+        run: |
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          php bench/bench.php 30000 5 >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/bench/bench.php
+++ b/bench/bench.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * FastExcel micro-benchmark.
  *
  * Usage:
@@ -11,6 +11,7 @@
  * export/import paths. Memory numbers are stable across runs; time on
  * shared CI runners is noisy, so deltas under ~10% should be ignored.
  */
+
 $autoload = getenv('BENCH_AUTOLOAD') ?: __DIR__.'/../vendor/autoload.php';
 
 require $autoload;

--- a/bench/bench.php
+++ b/bench/bench.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * FastExcel micro-benchmark.
+ *
+ * Usage:
+ *   php bench/bench.php [rows] [runs] [--json]
+ *   php bench/bench.php --compare base.json head.json
+ *
+ * Reports the median wall-clock time and peak memory for the main
+ * export/import paths. Memory numbers are stable across runs; time on
+ * shared CI runners is noisy, so deltas under ~10% should be ignored.
+ */
+
+$autoload = getenv('BENCH_AUTOLOAD') ?: __DIR__.'/../vendor/autoload.php';
+
+require $autoload;
+
+use OpenSpout\Common\Entity\Style\Style;
+use Rap2hpoutre\FastExcel\FastExcel;
+
+if (($argv[1] ?? '') === '--compare') {
+    exit(compareResults($argv[2], $argv[3]));
+}
+
+$rows = max(1, (int) ($argv[1] ?? 30000));
+$runs = max(1, (int) ($argv[2] ?? 3));
+$json = in_array('--json', $argv, true);
+
+$dir = sys_get_temp_dir().'/fastexcel-bench-'.getmypid();
+mkdir($dir);
+
+$collection = collect(array_map(fn ($i) => [
+    'id'     => $i,
+    'name'   => 'name_'.$i,
+    'email'  => 'user'.$i.'@example.com',
+    'amount' => $i * 1.5,
+], range(1, $rows)));
+
+$style = (new Style())->setFontBold();
+
+$results = [
+    'export_plain' => bench($runs, function () use ($collection, $dir) {
+        (new FastExcel($collection))->export($dir.'/plain.xlsx');
+    }),
+    'export_styled' => bench($runs, function () use ($collection, $dir, $style) {
+        (new FastExcel($collection))->headerStyle($style)->rowsStyle($style)->export($dir.'/styled.xlsx');
+    }),
+    'import' => bench($runs, function () use ($dir) {
+        (new FastExcel())->import($dir.'/plain.xlsx');
+    }),
+    'import_transposed' => bench($runs, function () use ($dir) {
+        (new FastExcel())->transpose()->import($dir.'/plain.xlsx');
+    }),
+];
+
+array_map('unlink', glob($dir.'/*'));
+rmdir($dir);
+
+if ($json) {
+    echo json_encode(['rows' => $rows, 'runs' => $runs, 'php' => PHP_VERSION, 'results' => $results], JSON_PRETTY_PRINT).PHP_EOL;
+} else {
+    printf("%d rows, median of %d runs (PHP %s)%s", $rows, $runs, PHP_VERSION, PHP_EOL);
+    foreach ($results as $name => $r) {
+        printf("  %-18s %8.3fs  %8.1f MB peak%s", $name, $r['median_s'], $r['peak_mb'], PHP_EOL);
+    }
+}
+
+function bench(int $runs, callable $fn): array
+{
+    $times = [];
+    $peak = 0;
+
+    for ($i = 0; $i < $runs; $i++) {
+        gc_collect_cycles();
+        if (function_exists('memory_reset_peak_usage')) {
+            memory_reset_peak_usage();
+        }
+        $start = hrtime(true);
+        $fn();
+        $times[] = (hrtime(true) - $start) / 1e9;
+        $peak = max($peak, memory_get_peak_usage(true));
+    }
+
+    sort($times);
+
+    return [
+        'median_s' => round($times[intdiv(count($times) - 1, 2)], 3),
+        'peak_mb'  => round($peak / 1048576, 1),
+    ];
+}
+
+function compareResults(string $baseFile, string $headFile): int
+{
+    $base = json_decode(file_get_contents($baseFile), true);
+    $head = json_decode(file_get_contents($headFile), true);
+
+    echo "### Benchmark: base vs PR ({$head['rows']} rows, median of {$head['runs']} runs, PHP {$head['php']})\n\n";
+    echo "| Benchmark | Base time | PR time | Δ time | Base peak mem | PR peak mem | Δ mem |\n";
+    echo "|---|---|---|---|---|---|---|\n";
+
+    $regression = false;
+
+    foreach ($head['results'] as $name => $h) {
+        $b = $base['results'][$name] ?? null;
+        if (!$b) {
+            printf("| %s | – | %.3fs | new | – | %.1f MB | new |\n", $name, $h['median_s'], $h['peak_mb']);
+            continue;
+        }
+        $dt = pct($b['median_s'], $h['median_s']);
+        $dm = pct($b['peak_mb'], $h['peak_mb']);
+        // Time on shared runners is noisy; only flag clear regressions.
+        if ($dt > 20 || $dm > 10) {
+            $regression = true;
+        }
+        printf(
+            "| %s | %.3fs | %.3fs | %+.1f%% | %.1f MB | %.1f MB | %+.1f%% |\n",
+            $name,
+            $b['median_s'],
+            $h['median_s'],
+            $dt,
+            $b['peak_mb'],
+            $h['peak_mb'],
+            $dm
+        );
+    }
+
+    echo "\n_Time deltas under ~10% are runner noise; memory deltas are reliable._\n";
+
+    if ($regression) {
+        echo "\n⚠️ **Possible performance regression detected** (time +20% or memory +10%).\n";
+    }
+
+    return 0;
+}
+
+function pct(float $base, float $head): float
+{
+    return $base > 0 ? (($head - $base) / $base) * 100 : 0.0;
+}

--- a/bench/bench.php
+++ b/bench/bench.php
@@ -11,7 +11,6 @@
  * export/import paths. Memory numbers are stable across runs; time on
  * shared CI runners is noisy, so deltas under ~10% should be ignored.
  */
-
 $autoload = getenv('BENCH_AUTOLOAD') ?: __DIR__.'/../vendor/autoload.php';
 
 require $autoload;
@@ -60,13 +59,13 @@ rmdir($dir);
 if ($json) {
     echo json_encode(['rows' => $rows, 'runs' => $runs, 'php' => PHP_VERSION, 'results' => $results], JSON_PRETTY_PRINT).PHP_EOL;
 } else {
-    printf("%d rows, median of %d runs (PHP %s)%s", $rows, $runs, PHP_VERSION, PHP_EOL);
-    foreach ($results as $name => $r) {
-        printf("  %-18s %8.3fs  %8.1f MB peak%s", $name, $r['median_s'], $r['peak_mb'], PHP_EOL);
+    printf('%d rows, median of %d runs (PHP %s)%s', $rows, $runs, PHP_VERSION, PHP_EOL);
+    foreach ($results as $name => $result) {
+        printf('  %-18s %8.3fs  %8.1f MB peak%s', $name, $result['median_s'], $result['peak_mb'], PHP_EOL);
     }
 }
 
-function bench(int $runs, callable $fn): array
+function bench(int $runs, callable $callback): array
 {
     $times = [];
     $peak = 0;
@@ -77,7 +76,7 @@ function bench(int $runs, callable $fn): array
             memory_reset_peak_usage();
         }
         $start = hrtime(true);
-        $fn();
+        $callback();
         $times[] = (hrtime(true) - $start) / 1e9;
         $peak = max($peak, memory_get_peak_usage(true));
     }
@@ -101,27 +100,27 @@ function compareResults(string $baseFile, string $headFile): int
 
     $regression = false;
 
-    foreach ($head['results'] as $name => $h) {
-        $b = $base['results'][$name] ?? null;
-        if (!$b) {
-            printf("| %s | – | %.3fs | new | – | %.1f MB | new |\n", $name, $h['median_s'], $h['peak_mb']);
+    foreach ($head['results'] as $name => $headResult) {
+        $baseResult = $base['results'][$name] ?? null;
+        if (!$baseResult) {
+            printf("| %s | – | %.3fs | new | – | %.1f MB | new |\n", $name, $headResult['median_s'], $headResult['peak_mb']);
             continue;
         }
-        $dt = pct($b['median_s'], $h['median_s']);
-        $dm = pct($b['peak_mb'], $h['peak_mb']);
+        $timeDelta = pct($baseResult['median_s'], $headResult['median_s']);
+        $memDelta = pct($baseResult['peak_mb'], $headResult['peak_mb']);
         // Time on shared runners is noisy; only flag clear regressions.
-        if ($dt > 20 || $dm > 10) {
+        if ($timeDelta > 20 || $memDelta > 10) {
             $regression = true;
         }
         printf(
             "| %s | %.3fs | %.3fs | %+.1f%% | %.1f MB | %.1f MB | %+.1f%% |\n",
             $name,
-            $b['median_s'],
-            $h['median_s'],
-            $dt,
-            $b['peak_mb'],
-            $h['peak_mb'],
-            $dm
+            $baseResult['median_s'],
+            $headResult['median_s'],
+            $timeDelta,
+            $baseResult['peak_mb'],
+            $headResult['peak_mb'],
+            $memDelta
         );
     }
 


### PR DESCRIPTION
## Summary

Adds a lightweight performance benchmark that runs on every PR and posts a base-vs-PR comparison to the workflow job summary. No external services, no tokens, no PR comments (works for fork PRs since it only needs `contents: read`).

## How it works

- `bench/bench.php` measures **median wall-clock time** (of 5 runs) and **peak memory** for the four main paths: plain export, styled export, import, and transposed import (30k rows by default). It also has a `--compare base.json head.json` mode that renders a markdown table.
- The `Benchmark` workflow benchmarks the PR head, then checks out only `src/` at the base sha (keeping `vendor/` and the bench script from the head, so both sides run under identical dependencies and PHP), benchmarks again, and writes the comparison to `$GITHUB_STEP_SUMMARY`.
- It flags a possible regression when time is +20% or peak memory is +10%. Time on shared runners is noisy (deltas under ~10% are meaningless); peak memory is deterministic and is the reliable signal.
- Skips gracefully on PRs whose head predates `bench/bench.php`.

## Example output (local run, master vs #406)

| Benchmark | Base time | PR time | Δ time | Base peak mem | PR peak mem | Δ mem |
|---|---|---|---|---|---|---|
| export_plain | 0.116s | 0.099s | -14.7% | 42.0 MB | 8.0 MB | -81.0% |
| export_styled | 0.128s | 0.101s | -21.1% | 58.0 MB | 8.0 MB | -86.2% |
| import | 0.135s | 0.132s | -2.2% | 58.0 MB | 10.0 MB | -82.8% |
| import_transposed | 0.142s | 0.133s | -6.3% | 58.0 MB | 10.0 MB | -82.8% |

Can also be run locally: `php bench/bench.php [rows] [runs] [--json]`.