### PR TITLE
fix(ci): benchmark base run and compare steps were silently failing

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,20 +34,24 @@ jobs:
 
       - name: Benchmark PR head
         if: steps.bench.outputs.exists == 'true'
-        run: php bench/bench.php 30000 5 --json | tee /tmp/head.json
+        run: |
+          set -o pipefail
+          php bench/bench.php 30000 5 --json | tee /tmp/head.json
 
       - name: Benchmark base branch
         if: github.event_name == 'pull_request' && steps.bench.outputs.exists == 'true'
         run: |
-          # Keep vendor/ and the bench script from the PR head; only swap the
-          # library code, so both sides run under identical dependencies.
-          cp bench/bench.php /tmp/bench.php
+          set -o pipefail
+          # Only swap the library code; vendor/ and the bench script stay from
+          # the PR head, so both sides run under identical dependencies.
           git checkout ${{ github.event.pull_request.base.sha }} -- src/
-          php /tmp/bench.php 30000 5 --json | tee /tmp/base.json
+          php bench/bench.php 30000 5 --json | tee /tmp/base.json
 
       - name: Compare
         if: github.event_name == 'pull_request' && steps.bench.outputs.exists == 'true'
-        run: php /tmp/bench.php --compare /tmp/base.json /tmp/head.json | tee -a "$GITHUB_STEP_SUMMARY"
+        run: |
+          set -o pipefail
+          php bench/bench.php --compare /tmp/base.json /tmp/head.json | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Single-run summary
         if: github.event_name != 'pull_request' && steps.bench.outputs.exists == 'true'

--- a/bench/bench.php
+++ b/bench/bench.php
@@ -12,16 +12,15 @@
  * shared CI runners is noisy, so deltas under ~10% should be ignored.
  */
 
-$autoload = getenv('BENCH_AUTOLOAD') ?: __DIR__.'/../vendor/autoload.php';
-
-require $autoload;
-
 use OpenSpout\Common\Entity\Style\Style;
 use Rap2hpoutre\FastExcel\FastExcel;
 
+// Compare mode is pure PHP; only benchmark mode needs the autoloader.
 if (($argv[1] ?? '') === '--compare') {
     exit(compareResults($argv[2], $argv[3]));
 }
+
+require getenv('BENCH_AUTOLOAD') ?: __DIR__.'/../vendor/autoload.php';
 
 $rows = max(1, (int) ($argv[1] ?? 30000));
 $runs = max(1, (int) ($argv[2] ?? 3));


### PR DESCRIPTION
Follow-up to #407. The base-benchmark and compare steps copied `bench.php` to `/tmp`, where its `__DIR__`-relative autoload path doesn't resolve, so both steps fataled — invisibly, because `| tee` swallowed the exit code and the job passed with an empty summary (caught by reading the raw step logs).

Fixes:
- `--compare` mode is handled before the `require` (it's pure PHP and doesn't need the autoloader)
- the `/tmp` copy is gone: the base step only checks out `src/` at the base sha, so the PR head's `bench/bench.php` and `vendor/` stay in place
- `set -o pipefail` in all three steps so a PHP fatal fails the step instead of hiding behind `tee`

Verified locally: compare mode runs from a directory with no `vendor/` nearby, and the full head→base→compare sequence produces the markdown table.