### PR TITLE
feat: select import sheet by name (#273)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ You can also import a specific sheet by its number:
 $users = (new FastExcel)->sheet(3)->import('file.xlsx');
 ```
 
+`sheet()` also accepts a sheet name, so you can select a sheet without knowing its position:
+
+```php
+$users = (new FastExcel)->sheet('Users')->import('file.xlsx');
+```
+
 Import multiple sheets with sheets names:
 
 ```php

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -86,7 +86,7 @@ class FastExcel
     }
 
     /**
-     * @param $sheet_number
+     * @param int|string $sheet_number 1-based index or sheet name
      *
      * @return $this
      */

--- a/src/Importable.php
+++ b/src/Importable.php
@@ -18,7 +18,7 @@ use OpenSpout\Writer\Common\AbstractOptions;
 trait Importable
 {
     /**
-     * @var int
+     * @var int|string
      */
     private $sheet_number = 1;
 
@@ -44,7 +44,7 @@ trait Importable
         $reader = $this->reader($path);
 
         foreach ($reader->getSheetIterator() as $key => $sheet) {
-            if ($this->sheet_number == $key) {
+            if ($this->sheetMatches($key, $sheet)) {
                 $collection = $this->importSheet($sheet, $callback);
                 break;
             }
@@ -73,7 +73,7 @@ trait Importable
 
             try {
                 foreach ($reader->getSheetIterator() as $key => $sheet) {
-                    if ($this->sheet_number != $key) {
+                    if (!$this->sheetMatches($key, $sheet)) {
                         continue;
                     }
                     if ($this->transpose) {
@@ -88,6 +88,24 @@ trait Importable
                 $reader->close();
             }
         });
+    }
+
+    /**
+     * Whether the given sheet is the one selected via sheet().
+     * Selection accepts a 1-based index (int) or a sheet name (string).
+     *
+     * @param int            $key
+     * @param SheetInterface $sheet
+     *
+     * @return bool
+     */
+    private function sheetMatches(int $key, SheetInterface $sheet): bool
+    {
+        if (is_string($this->sheet_number)) {
+            return $this->sheet_number === $sheet->getName();
+        }
+
+        return (int) $this->sheet_number === $key;
     }
 
     /**

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -278,6 +278,39 @@ class FastExcelTest extends TestCase
     }
 
     /**
+     * A sheet can be selected for import by its name, not only by its 1-based index.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     */
+    public function testImportSheetByName()
+    {
+        $first = collect([['test' => 'row1 col1'], ['test' => 'row2 col1'], ['test' => 'row3 col1']]);
+        $second = $this->collection();
+
+        $file = __DIR__.'/test_import_sheet_by_name.xlsx';
+        $sheets = new SheetCollection([
+            'First sheet'  => $first,
+            'Second sheet' => $second,
+        ]);
+        (new FastExcel($sheets))->export($file);
+
+        // Select the second sheet by its NAME (proves name selection, not index).
+        $this->assertEquals($second, (new FastExcel())->sheet('Second sheet')->import($file));
+
+        // Selecting the first sheet by name returns the first sheet's data.
+        $this->assertEquals($first, (new FastExcel())->sheet('First sheet')->import($file));
+
+        // Index selection still works: sheet 2 is the second sheet.
+        $this->assertEquals($second, (new FastExcel())->sheet(2)->import($file));
+
+        unlink($file);
+    }
+
+    /**
      * @throws \OpenSpout\Common\Exception\IOException
      * @throws \OpenSpout\Common\Exception\InvalidArgumentException
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException


### PR DESCRIPTION
## What

`sheet()` now accepts a **sheet name** (string) in addition to the 1-based index. This lets you select a sheet to import without knowing its position in the workbook.

```php
// still works — select by 1-based index
$rows = (new FastExcel)->sheet(2)->import('file.xlsx');

// new — select by sheet name
$rows = (new FastExcel)->sheet('Users')->import('file.xlsx');
```

## How

A new private `sheetMatches()` helper resolves the selected sheet:

- a **string** matches against the sheet's name (`$sheet->getName()`)
- an **int** matches against the 1-based iterator key (previous behaviour)

It is used by both `import()` and `importLazy()`, so name selection works for the eager and lazy import paths alike. Passing an int keeps the existing index-based behaviour, so the change is **fully backward compatible**.

## Tests & docs

- Added `testImportSheetByName`: exports a two-named-sheet xlsx, imports the **second** sheet **by name**, asserts the rows match that sheet's data (proving name selection, not index), and verifies index selection still works. Full suite green.
- Added a short README note with a one-line example under the sheet-selection docs.

Closes #273