### PR TITLE
fix: close reader on exception during import (#241)

### DIFF
--- a/src/Importable.php
+++ b/src/Importable.php
@@ -43,13 +43,16 @@ trait Importable
     {
         $reader = $this->reader($path);
 
-        foreach ($reader->getSheetIterator() as $key => $sheet) {
-            if ($this->sheet_number == $key) {
-                $collection = $this->importSheet($sheet, $callback);
-                break;
+        try {
+            foreach ($reader->getSheetIterator() as $key => $sheet) {
+                if ($this->sheet_number == $key) {
+                    $collection = $this->importSheet($sheet, $callback);
+                    break;
+                }
             }
+        } finally {
+            $reader->close();
         }
-        $reader->close();
 
         return collect($collection ?? []);
     }
@@ -105,14 +108,18 @@ trait Importable
         $reader = $this->reader($path);
 
         $collections = [];
-        foreach ($reader->getSheetIterator() as $sheet) {
-            if ($this->with_sheets_names) {
-                $collections[$sheet->getName()] = $this->importSheet($sheet, $callback);
-            } else {
-                $collections[] = $this->importSheet($sheet, $callback);
+
+        try {
+            foreach ($reader->getSheetIterator() as $sheet) {
+                if ($this->with_sheets_names) {
+                    $collections[$sheet->getName()] = $this->importSheet($sheet, $callback);
+                } else {
+                    $collections[] = $this->importSheet($sheet, $callback);
+                }
             }
+        } finally {
+            $reader->close();
         }
-        $reader->close();
 
         return new SheetCollection($collections);
     }

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -513,4 +513,36 @@ class IssuesTest extends TestCase
 
         unlink($file);
     }
+
+    /**
+     * Issue #241: when the row callback throws, import() (and importSheets())
+     * must still close the reader. Previously close() ran after the loop, so an
+     * exception in the callback leaked the open reader (and XLSX temp files).
+     * Wrapping the loop in try/finally releases the reader; a follow-up import
+     * of the same file must then succeed.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testIssue241ReaderClosedWhenCallbackThrows()
+    {
+        $file = __DIR__.'/test1.xlsx';
+
+        // The callback throws mid-import; the exception must propagate.
+        try {
+            (new FastExcel())->import($file, function () {
+                throw new \RuntimeException('boom');
+            });
+            $this->fail('Expected RuntimeException was not thrown.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('boom', $e->getMessage());
+        }
+
+        // Regression guard: the reader was released, so re-importing the same
+        // file works and returns the expected rows.
+        $rows = (new FastExcel())->import($file);
+        $this->assertInstanceOf(Collection::class, $rows);
+        $this->assertEquals($this->collection(), $rows);
+    }
 }


### PR DESCRIPTION
## Problem

`import()` and `importSheets()` called `$reader->close()` **after** the row loop with no `try/finally`. When the row callback throws, the exception propagates before `close()` runs, leaking the open reader (and the XLSX temp files it holds). `importLazy()` already guards this correctly with `try/finally`.

## Fix

Wrap the sheet-iteration loop in both `import()` and `importSheets()` in `try { ... } finally { $reader->close(); }`, so the reader is always released even when a callback throws — copying the pattern `importLazy()` already uses.

## Test

Adds `testIssue241ReaderClosedWhenCallbackThrows`: imports a fixture with a callback that throws a `RuntimeException` (asserting it propagates), then re-imports the same file normally and asserts it returns the expected rows — a regression guard that the reader was released.

All 45 tests pass.

Closes #241