### PR TITLE
feat: add escapeFormulas() to write values starting with = as text (#356)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,16 @@ precedence over `stringValues()`:
     ->export('users.xlsx');
 ```
 
+### Escape formulas (prevent formula injection)
+
+By default any string starting with `=` (e.g. `=1+2`) is written as a live
+formula cell, which can corrupt the file or enable CSV/formula injection. Call
+`escapeFormulas()` to write string values as literal text cells instead:
+
+```php
+(new FastExcel($rows))->escapeFormulas()->export('file.xlsx');
+```
+
 ## Why?
 
 FastExcel is intended at being Laravel-flavoured [Spout](https://github.com/box/spout):

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -5,6 +5,8 @@ namespace Rap2hpoutre\FastExcel;
 use DateTimeInterface;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use OpenSpout\Common\Entity\Cell;
+use OpenSpout\Common\Entity\Cell\StringCell;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Writer\Common\AbstractOptions;
@@ -35,6 +37,9 @@ trait Exportable
 
     /** @var bool */
     private $string_values = false;
+
+    /** @var bool */
+    private $escape_formulas = false;
 
     /** @var array<string, string> */
     private $column_formats = [];
@@ -73,6 +78,20 @@ trait Exportable
     public function stringValues(bool $enabled = true): static
     {
         $this->string_values = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * Write string values as explicit text cells so a value starting with "="
+     * (or other formula-triggering input) is never emitted as a live formula
+     * cell. Protects against CSV/formula injection and "corrupt file" errors.
+     *
+     * @param bool $enabled
+     */
+    public function escapeFormulas(bool $enabled = true): static
+    {
+        $this->escape_formulas = $enabled;
 
         return $this;
     }
@@ -276,7 +295,7 @@ trait Exportable
             $this->writeHeader($writer, $collection->first());
         }
 
-        $use_styles = $this->rows_style || $this->column_styles;
+        $use_styles = $this->rows_style || $this->column_styles || $this->escape_formulas;
 
         // Write rows one by one so Row objects can be garbage-collected as
         // they are written, instead of materializing them all up front.
@@ -457,6 +476,18 @@ trait Exportable
      */
     private function createRow(array $values = [], ?Style $rows_style = null, array $column_styles = []): Row
     {
-        return Row::fromValuesWithStyles($values, $rows_style, $column_styles);
+        if (!$this->escape_formulas) {
+            return Row::fromValuesWithStyles($values, $rows_style, $column_styles);
+        }
+
+        $cells = [];
+        foreach ($values as $key => $value) {
+            $style = $column_styles[$key] ?? null;
+            $cells[] = is_string($value)
+                ? new StringCell($value, $style)
+                : Cell::fromValue($value, $style);
+        }
+
+        return new Row($cells, $rows_style);
     }
 }

--- a/src/Facades/FastExcel.php
+++ b/src/Facades/FastExcel.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Illuminate\Support\Collection   import($path, callable $callback = null)
  * @method static string                           export($path, callable $callback = null)
  * @method static \Illuminate\Support\Collection   importSheets($path, callable $callback = null)
+ * @method static \Rap2hpoutre\FastExcel\FastExcel escapeFormulas($enabled = true)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureCsv($delimiter = ',', $enclosure = '"', $encoding = 'UTF-8', $bom = false)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureReaderUsing(?callable $callback = null)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureWriterUsing(?callable $callback = null)

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -513,4 +513,49 @@ class IssuesTest extends TestCase
 
         unlink($file);
     }
+
+    /**
+     * A string value starting with "=" must be written as literal text (an
+     * inline string) when escapeFormulas() is enabled, instead of a live
+     * formula cell. This protects against CSV/formula injection and the
+     * "corrupt file" errors reported in issue #356.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     */
+    public function testIssue356()
+    {
+        $file = __DIR__.'/issue356.xlsx';
+        $rows = new Collection([['formula' => '=1+2']]);
+
+        // With escapeFormulas(): the value is stored as literal inline-string
+        // text, so no live formula element ("<f>...</f>") is written.
+        (new FastExcel(clone $rows))->escapeFormulas()->export($file);
+        $xml = $this->readXlsxSheetXml($file);
+        $this->assertStringContainsString('<t>=1+2</t>', $xml);
+        $this->assertStringNotContainsString('<f>', $xml);
+        unlink($file);
+
+        // Without escapeFormulas(): the same value is emitted as a live
+        // formula cell (the pre-existing, unsafe behavior).
+        (new FastExcel(clone $rows))->export($file);
+        $xml = $this->readXlsxSheetXml($file);
+        $this->assertStringContainsString('<f>1+2</f>', $xml);
+        unlink($file);
+    }
+
+    /**
+     * Read the first worksheet XML out of an XLSX file (a zip archive).
+     */
+    private function readXlsxSheetXml(string $file): string
+    {
+        $zip = new \ZipArchive();
+        $zip->open($file);
+        $xml = $zip->getFromName('xl/worksheets/sheet1.xml');
+        $zip->close();
+
+        return $xml;
+    }
 }


### PR DESCRIPTION
## Problem

OpenSpout's `Cell::fromValue()` turns **any** string whose first character is `=` into a `FormulaCell`. FastExcel writes every row through that path, so a value like `"=1+2"` is emitted as a **live formula cell**. This corrupts files ("recovered/repaired" prompts in Excel) and is a classic **CSV/formula injection** vector. There is no mitigation today — `stringValues()` only casts int/float to string and does nothing for a value that is already a string.

## Change

Adds an opt-in `escapeFormulas()` export option:

```php
(new FastExcel($rows))->escapeFormulas()->export('file.xlsx');
```

When enabled, string values are written as `StringCell` (literal text that can never become a formula), while non-string values still go through `Cell::fromValue()`. Row and per-column styling are preserved. The no-style fast path in `writeRowsFromCollection()` now also routes through `createRow()` when the flag is on, so the escaping applies even when no styles are configured.

## Details

- `src/Exportable.php`: new `$escape_formulas` flag, `escapeFormulas(bool $enabled = true)` setter, and `createRow()` builds `StringCell`/`Cell` explicitly when the flag is set.
- `src/Facades/FastExcel.php`: `@method` docblock entry.
- `README.md`: short "Escape formulas (prevent formula injection)" note with a one-line example.

## Test

`testIssue356` exports `['formula' => '=1+2']` and asserts:
- **with** `escapeFormulas()` the cell is stored as inline-string text (`<t>=1+2</t>`, no `<f>` formula element);
- **without** it, the same value is written as a live formula (`<f>1+2</f>`).

The assertion inspects the written worksheet XML directly, because OpenSpout's XLSX **reader** re-runs every inline string through `Cell::fromValue()` and would re-interpret a literal `=1+2` as a formula on read — so a round-trip import cannot distinguish the two. The file-level check verifies the actual on-disk protection (what Excel sees).

Full suite: 45 passing (was 44).

## Scope — issue #356 is only partially addressed

Measured on the written files: in **xlsx** only a leading `=` ever produced a formula cell, so this PR fixes that case. `+`, `-` and `@` were already written as literal text there.

In **csv**, all of `= + - @` are still written raw and `escapeFormulas()` does not change that — `StringCell` is indistinguishable from a plain value to the CSV writer (output is byte-identical with and without the flag). Since csv is where Excel evaluates those prefixes on open, that part of #356 needs a separate `'`-prefix fix.

Refs #356 (kept open for the csv case) — see https://github.com/rap2hpoutre/fast-excel/issues/356#issuecomment-5123169983
