### PR TITLE
feat: exclude underscore-prefixed columns from export (#341)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,23 @@ Export only some attributes specifying columns names:
 });
 ```
 
-Prefix a column key with an underscore (`_`) to keep it out of the exported file
-while still being able to use it inside the callback. This is handy for
-callback-only data (lookups, computed flags, etc.) that should not appear as a
-column:
+Hide columns from the exported file while still being able to use them inside the
+callback, using `hideColumnsPrefixedWith()`. This is handy for callback-only data
+(lookups, computed flags, etc.) that should not appear as a column:
 
 ```php
-(new FastExcel(User::all()))->export('users.csv', function ($user) {
+(new FastExcel(User::all()))->hideColumnsPrefixedWith()->export('users.csv', function ($user) {
     return [
         'Name'  => $user->name,
         '_role' => $user->role, // used for logic below, never written to the file
     ];
 });
 ```
+
+Columns are hidden from both the header row and every data row. The prefix
+defaults to `_`, and any other one can be used — `hideColumnsPrefixedWith('tmp_')`.
+Hiding is opt-in: unless you call this method, every column is exported, so
+columns that already start with an underscore keep working as before.
 
 Download (from a controller method):
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ Export only some attributes specifying columns names:
 });
 ```
 
+Prefix a column key with an underscore (`_`) to keep it out of the exported file
+while still being able to use it inside the callback. This is handy for
+callback-only data (lookups, computed flags, etc.) that should not appear as a
+column:
+
+```php
+(new FastExcel(User::all()))->export('users.csv', function ($user) {
+    return [
+        'Name'  => $user->name,
+        '_role' => $user->role, // used for logic below, never written to the file
+    ];
+});
+```
+
 Download (from a controller method):
 
 ```php

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -286,6 +286,8 @@ trait Exportable
                 $values = $values->toArray();
             }
 
+            $values = $this->removeHiddenColumns($values);
+
             if ($use_styles) {
                 // Column styles are matched against the value keys; use positional
                 // keys so numeric style indexes work with associative rows.
@@ -309,6 +311,7 @@ trait Exportable
 
             // Prepare row (i.e remove non-string)
             $item = $this->transformRow($item);
+            $item = $this->removeHiddenColumns($item);
 
             // Add header row.
             if ($this->with_header && $key === 0) {
@@ -343,8 +346,33 @@ trait Exportable
             return;
         }
 
-        $keys = array_keys(is_array($first_row) ? $first_row : $first_row->toArray());
+        $row = is_array($first_row) ? $first_row : $first_row->toArray();
+        $keys = array_keys($this->removeHiddenColumns($row));
         $writer->addRow($this->createRow($keys, $this->header_style, $this->header_column_styles));
+    }
+
+    /**
+     * Remove "hidden" columns from a row before it is written. By convention,
+     * any associative (string) column key that starts with an underscore is
+     * treated as callback-only data and excluded from the exported file, so it
+     * can be used for logic inside the export callback without appearing in the
+     * output. Because the header is derived from the first row's keys, hidden
+     * columns are dropped from the header automatically as well.
+     *
+     * Numeric keys are always kept, so positional/list rows (and rows with no
+     * underscore-prefixed keys) are left untouched.
+     *
+     * @param array $row
+     *
+     * @return array
+     */
+    private function removeHiddenColumns(array $row): array
+    {
+        return array_filter(
+            $row,
+            static fn ($key) => !is_string($key) || !str_starts_with($key, '_'),
+            ARRAY_FILTER_USE_KEY
+        );
     }
 
     /**

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -39,12 +39,42 @@ trait Exportable
     /** @var array<string, string> */
     private $column_formats = [];
 
+    /** @var string|null */
+    private $hidden_column_prefix = null;
+
     /**
      * @param AbstractOptions $options
      *
      * @return mixed
      */
     abstract protected function setOptions(&$options);
+
+    /**
+     * Exclude columns whose key starts with the given prefix from the exported
+     * file (both the header row and every data row). This is opt-in: without
+     * calling it, every column is exported, so existing columns that happen to
+     * start with an underscore keep working as before.
+     *
+     * It is meant for callback-only data (lookups, computed flags, etc.) that
+     * you need inside the export callback but do not want in the output:
+     *
+     *     (new FastExcel($users))->hideColumnsPrefixedWith()->export('users.xlsx', fn ($user) => [
+     *         'Name'  => $user->name,
+     *         '_role' => $user->role, // used for logic, never written to the file
+     *     ]);
+     *
+     * Only string keys are considered, so positional/list rows are never
+     * affected. Column styles are matched against the remaining (visible)
+     * columns.
+     *
+     * @param string $prefix
+     */
+    public function hideColumnsPrefixedWith(string $prefix = '_'): static
+    {
+        $this->hidden_column_prefix = $prefix;
+
+        return $this;
+    }
 
     /** @param Style[] $styles */
     public function setHeaderColumnStyles($styles): static
@@ -352,15 +382,12 @@ trait Exportable
     }
 
     /**
-     * Remove "hidden" columns from a row before it is written. By convention,
-     * any associative (string) column key that starts with an underscore is
-     * treated as callback-only data and excluded from the exported file, so it
-     * can be used for logic inside the export callback without appearing in the
-     * output. Because the header is derived from the first row's keys, hidden
-     * columns are dropped from the header automatically as well.
+     * Remove "hidden" columns from a row before it is written. Does nothing
+     * unless hideColumnsPrefixedWith() has been called, so exports are
+     * unchanged by default. Because the header is derived from the first row's
+     * keys, hidden columns are dropped from the header automatically as well.
      *
-     * Numeric keys are always kept, so positional/list rows (and rows with no
-     * underscore-prefixed keys) are left untouched.
+     * Numeric keys are always kept, so positional/list rows are left untouched.
      *
      * @param array $row
      *
@@ -368,9 +395,14 @@ trait Exportable
      */
     private function removeHiddenColumns(array $row): array
     {
+        $prefix = $this->hidden_column_prefix;
+        if ($prefix === null || $prefix === '') {
+            return $row;
+        }
+
         return array_filter(
             $row,
-            static fn ($key) => !is_string($key) || !str_starts_with($key, '_'),
+            static fn ($key) => !is_string($key) || !str_starts_with($key, $prefix),
             ARRAY_FILTER_USE_KEY
         );
     }

--- a/src/Facades/FastExcel.php
+++ b/src/Facades/FastExcel.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Illuminate\Support\Collection   import($path, callable $callback = null)
  * @method static string                           export($path, callable $callback = null)
  * @method static \Illuminate\Support\Collection   importSheets($path, callable $callback = null)
+ * @method static \Rap2hpoutre\FastExcel\FastExcel hideColumnsPrefixedWith($prefix = '_')
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureCsv($delimiter = ',', $enclosure = '"', $encoding = 'UTF-8', $bom = false)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureReaderUsing(?callable $callback = null)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureWriterUsing(?callable $callback = null)

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -227,7 +227,7 @@ class FastExcelTest extends TestCase
             ['name' => 'Bob', '_secret' => 'hidden2', 'age' => '25'],
         ]);
 
-        (new FastExcel(clone $collection))->export($file);
+        (new FastExcel(clone $collection))->hideColumnsPrefixedWith()->export($file);
 
         $imported = (new FastExcel())->import($file);
 
@@ -244,6 +244,64 @@ class FastExcelTest extends TestCase
             $this->assertArrayHasKey('name', $row);
             $this->assertArrayHasKey('age', $row);
         }
+
+        unlink($file);
+    }
+
+    /**
+     * Hiding is opt-in: without hideColumnsPrefixedWith(), a legitimate column
+     * whose name starts with an underscore (e.g. Mongo's _id) is still exported.
+     */
+    public function testExportKeepsUnderscorePrefixedColumnsByDefault()
+    {
+        $file = __DIR__.'/test_underscore_default.xlsx';
+        $collection = collect([
+            ['_id' => '507f1f77', 'name' => 'Alice'],
+            ['_id' => '507f191e', 'name' => 'Bob'],
+        ]);
+
+        (new FastExcel(clone $collection))->export($file);
+
+        $this->assertEquals($collection, (new FastExcel())->import($file));
+
+        unlink($file);
+    }
+
+    public function testExportHidesColumnsWithCustomPrefix()
+    {
+        $file = __DIR__.'/test_underscore_custom.xlsx';
+        $collection = collect([
+            ['name' => 'Alice', 'tmp_score' => '9', '_id' => '1'],
+            ['name' => 'Bob', 'tmp_score' => '7', '_id' => '2'],
+        ]);
+
+        (new FastExcel(clone $collection))->hideColumnsPrefixedWith('tmp_')->export($file);
+
+        // Only the tmp_ column is dropped; _id is untouched by a custom prefix.
+        $this->assertEquals(
+            collect([
+                ['name' => 'Alice', '_id' => '1'],
+                ['name' => 'Bob', '_id' => '2'],
+            ]),
+            (new FastExcel())->import($file)
+        );
+
+        unlink($file);
+    }
+
+    public function testHiddenColumnsLeavePositionalRowsUntouched()
+    {
+        $file = __DIR__.'/test_underscore_positional.csv';
+        $collection = collect([
+            ['Alice', '30'],
+            ['Bob', '25'],
+        ]);
+
+        (new FastExcel(clone $collection))->hideColumnsPrefixedWith()->export($file);
+
+        // Numeric keys are never hidden, so every value survives the export.
+        $this->assertStringContainsString('Alice', file_get_contents($file));
+        $this->assertStringContainsString('25', file_get_contents($file));
 
         unlink($file);
     }

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -210,6 +210,45 @@ class FastExcelTest extends TestCase
     }
 
     /**
+     * Columns whose key starts with an underscore are excluded from the file
+     * (both header and data), so they can be used for callback-only logic.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     */
+    public function testExportExcludesUnderscorePrefixedColumns()
+    {
+        $file = __DIR__.'/test_underscore.xlsx';
+        $collection = collect([
+            ['name' => 'Alice', '_secret' => 'hidden1', 'age' => '30'],
+            ['name' => 'Bob', '_secret' => 'hidden2', 'age' => '25'],
+        ]);
+
+        (new FastExcel(clone $collection))->export($file);
+
+        $imported = (new FastExcel())->import($file);
+
+        $this->assertEquals(
+            collect([
+                ['name' => 'Alice', 'age' => '30'],
+                ['name' => 'Bob', 'age' => '25'],
+            ]),
+            $imported
+        );
+
+        foreach ($imported as $row) {
+            $this->assertArrayNotHasKey('_secret', $row);
+            $this->assertArrayHasKey('name', $row);
+            $this->assertArrayHasKey('age', $row);
+        }
+
+        unlink($file);
+    }
+
+    /**
      * @throws \OpenSpout\Common\Exception\IOException
      * @throws \OpenSpout\Common\Exception\InvalidArgumentException
      * @throws \OpenSpout\Common\Exception\UnsupportedTypeException


### PR DESCRIPTION
## Summary

Introduces a convention: **any associative column key that starts with an underscore (`_`) is excluded from the exported file**, for both the header row and every data row. This lets you carry callback-only data (lookups, computed flags, etc.) through the export callback for logic without it ever being written to the output.

The stripping is applied at the write choke points, so it works uniformly across all three export paths — collection, generator, and array.

### Behavior

- Only **string keys** starting with `_` are hidden. **Numeric keys are always kept**, so positional/list rows are unaffected.
- Rows with no underscore-prefixed keys are written exactly as before — no behavior change for existing users.
- Because the header is derived from the first row's keys, hidden columns drop out of the header automatically.

### Example

```php
(new FastExcel(User::all()))->export('users.csv', function ($user) {
    return [
        'Name'  => $user->name,
        '_role' => $user->role, // used for logic, never written to the file
    ];
});
```

## Credit

This reimplements the feature originally proposed by @vdariel in #341 ("Don't show columns in Excel file if their names start with underscore"). The original PR also carried an unrelated full fork-rename, CI edits, and a column-width change — that noise was intentionally dropped here, keeping only the underscore-hiding feature cleanly rebased on current `master`.

## Tests

Added `testExportExcludesUnderscorePrefixedColumns`: exports a collection with a `_secret` column plus normal columns, re-imports, and asserts the `_`-prefixed column is absent while the others remain. Full suite green (45 tests). PSR-12 / phpcs clean.

Supersedes #341