### PR TITLE
feat: limit imported rows with limitRows() (#248)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ $users = (new FastExcel)->import('file.xlsx', function ($line) {
 });
 ```
 
+Limit the number of data rows imported with `limitRows` (headers excluded). It works with both `import` and `importLazy`:
+
+```php
+$collection = (new FastExcel)->limitRows(100)->import('file.xlsx');
+```
+
 ## Facades
 
 You may use FastExcel with the optional Facade. Add the following line to ``config/app.php`` under the ``aliases`` key.

--- a/src/Facades/FastExcel.php
+++ b/src/Facades/FastExcel.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Illuminate\Support\Collection   import($path, callable $callback = null)
  * @method static string                           export($path, callable $callback = null)
  * @method static \Illuminate\Support\Collection   importSheets($path, callable $callback = null)
+ * @method static \Rap2hpoutre\FastExcel\FastExcel limitRows(?int $rows = null)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureCsv($delimiter = ',', $enclosure = '"', $encoding = 'UTF-8', $bom = false)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureReaderUsing(?callable $callback = null)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureWriterUsing(?callable $callback = null)

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -37,6 +37,11 @@ class FastExcel
     private $start_row = 1;
 
     /**
+     * @var int|null
+     */
+    private $end_row = null;
+
+    /**
      * @var bool
      */
     private $transpose = false;
@@ -123,6 +128,20 @@ class FastExcel
     public function startRow(int $row)
     {
         $this->start_row = $row;
+
+        return $this;
+    }
+
+    /**
+     * Limit the number of data rows imported. Pass null to remove the limit.
+     *
+     * @param int|null $rows
+     *
+     * @return $this
+     */
+    public function limitRows(?int $rows = null)
+    {
+        $this->end_row = $rows;
 
         return $this;
     }

--- a/src/Importable.php
+++ b/src/Importable.php
@@ -12,6 +12,7 @@ use OpenSpout\Writer\Common\AbstractOptions;
  * Trait Importable.
  *
  * @property int  $start_row
+ * @property ?int $end_row
  * @property bool $transpose
  * @property bool $with_header
  */
@@ -379,6 +380,7 @@ trait Importable
         $headers = [];
         $collection = [];
         $count_header = 0;
+        $count_rows = 0;
 
         foreach ($sheet->getRowIterator() as $key => $rowAsObject) {
             $row = array_map(function (Cell $cell) {
@@ -399,6 +401,10 @@ trait Importable
                 }
             } else {
                 $collection[] = $current;
+            }
+
+            if ($this->end_row !== null && ++$count_rows >= $this->end_row) {
+                break;
             }
         }
 
@@ -421,6 +427,7 @@ trait Importable
     {
         $headers = [];
         $count_header = 0;
+        $count_rows = 0;
 
         foreach ($sheet->getRowIterator() as $key => $rowAsObject) {
             $row = array_map(function (Cell $cell) {
@@ -442,6 +449,10 @@ trait Importable
                 }
             } else {
                 yield $current;
+            }
+
+            if ($this->end_row !== null && ++$count_rows >= $this->end_row) {
+                break;
             }
         }
     }

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -405,4 +405,72 @@ class FastExcelTest extends TestCase
             ['col1' => '1/3/2022'],
         ]), $collection);
     }
+
+    /**
+     * limitRows() stops the eager import after N data rows (headers excluded).
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testImportWithLimitRows()
+    {
+        $collection = (new FastExcel())->limitRows(2)->import(__DIR__.'/test1.xlsx');
+
+        // Only the first two data rows are returned, still keyed by their headers.
+        $this->assertEquals(collect([
+            ['col1' => 'row1 col1', 'col2' => 'row1 col2'],
+            ['col1' => 'row2 col1', 'col2' => ''],
+        ]), $collection);
+    }
+
+    /**
+     * limitRows(null) removes the limit and imports every data row.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testImportWithoutLimitRows()
+    {
+        $collection = (new FastExcel())->limitRows(null)->import(__DIR__.'/test1.xlsx');
+
+        $this->assertEquals($this->collection(), $collection);
+    }
+
+    /**
+     * limitRows() counts data rows, not raw iterator keys, so it composes with startRow().
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testImportWithLimitRowsAndStartRow()
+    {
+        $collection = (new FastExcel())
+            ->startRow(2)
+            ->withoutHeaders()
+            ->limitRows(1)
+            ->import(__DIR__.'/test1.xlsx');
+
+        $this->assertCount(1, $collection);
+        $this->assertEquals(['row1 col1', 'row1 col2'], $collection->first());
+    }
+
+    /**
+     * The lazy import path honors limitRows() identically to the eager path.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testImportLazyWithLimitRows()
+    {
+        $collection = (new FastExcel())->limitRows(2)->importLazy(__DIR__.'/test1.xlsx')->collect();
+
+        $this->assertEquals(collect([
+            ['col1' => 'row1 col1', 'col2' => 'row1 col2'],
+            ['col1' => 'row2 col1', 'col2' => ''],
+        ]), $collection);
+    }
 }


### PR DESCRIPTION
## What

Adds a `limitRows(?int $rows = null)` setter that stops an import after `N` data rows have been read.

```php
$collection = (new FastExcel)->limitRows(100)->import('file.xlsx');
```

## Details

- The limit counts **data rows** (after header handling), not raw iterator keys, so it composes intuitively with `withoutHeaders()` and `startRow()`.
- Both import paths honor it identically:
  - eager `import()` / `importSheet()`
  - lazy `importLazy()` / `importSheetGenerator()` — which additionally means it stops reading early, keeping the streaming/low-memory benefit.
- Passing `null` (the default) removes the limit.
- Added the `@method` hint to the Facade, the `@property ?int $end_row` docblock to the `Importable` trait, a README note + one-line example, and tests covering the eager path, the lazy path, `null` (no limit), and composition with `startRow()`/`withoutHeaders()`.

All tests green (`vendor/bin/phpunit tests`), `phpcs` clean.

## Credit

Reimplements @atymic's original idea from #248 cleanly on current `master` (the original diff predated the `normalizeRow()` refactor and had a null-handling bug that broke immediately when no limit was set).

Supersedes #248