### PR TITLE
feat: allow OpenSpout Cell instances as export values (#306)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,24 @@ precedence over `stringValues()`:
     ->export('users.xlsx');
 ```
 
+### Use raw OpenSpout Cell instances
+
+For full control over a single cell's type or style, a row value may be an
+`OpenSpout\Common\Entity\Cell` instance. It is written through as-is, while the
+other (scalar) values in the row keep their normal handling:
+
+```php
+use OpenSpout\Common\Entity\Cell;
+use OpenSpout\Common\Entity\Style\Style;
+
+$users = collect([
+    ['name' => 'John', 'note' => Cell::fromValue('paid', (new Style())->setFontBold())],
+    ['name' => 'Jane', 'note' => 'pending'],
+]);
+
+(new FastExcel($users))->export('users.xlsx');
+```
+
 ## Why?
 
 FastExcel is intended at being Laravel-flavoured [Spout](https://github.com/box/spout):

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -293,8 +293,10 @@ trait Exportable
                 $writer->addRow($this->createRow(array_values($values), $this->rows_style, $this->column_styles));
             } elseif ($this->rowHasCell($values)) {
                 // Row::fromValues() cannot accept Cell instances; build the row
-                // manually so pre-built cells are written through as-is.
-                $writer->addRow($this->createRow(array_values($values)));
+                // manually so pre-built cells are written through as-is. We
+                // already know it has a cell, so call the builder directly
+                // instead of createRow() to avoid a second rowHasCell() scan.
+                $writer->addRow($this->buildRowFromCells(array_values($values)));
             } else {
                 $writer->addRow(Row::fromValues($values));
             }
@@ -467,9 +469,19 @@ trait Exportable
             return Row::fromValuesWithStyles($values, $rows_style, $column_styles);
         }
 
-        // A value is already a Cell: use it as-is and convert the remaining
-        // scalars, preserving any per-column style. Row::fromValuesWithStyles()
-        // cannot be used here because it calls Cell::fromValue() on every value.
+        return $this->buildRowFromCells($values, $rows_style, $column_styles);
+    }
+
+    /**
+     * Build a Row when at least one value is already a Cell: use those cells
+     * as-is and convert the remaining scalars, preserving any per-column style.
+     * Row::fromValuesWithStyles() cannot be used here because it calls
+     * Cell::fromValue() on every value.
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
+    private function buildRowFromCells(array $values, ?Style $rows_style = null, array $column_styles = []): Row
+    {
         $cells = [];
         foreach ($values as $key => $value) {
             $cells[] = $value instanceof Cell

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -5,6 +5,7 @@ namespace Rap2hpoutre\FastExcel;
 use DateTimeInterface;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Writer\Common\AbstractOptions;
@@ -290,6 +291,10 @@ trait Exportable
                 // Column styles are matched against the value keys; use positional
                 // keys so numeric style indexes work with associative rows.
                 $writer->addRow($this->createRow(array_values($values), $this->rows_style, $this->column_styles));
+            } elseif ($this->rowHasCell($values)) {
+                // Row::fromValues() cannot accept Cell instances; build the row
+                // manually so pre-built cells are written through as-is.
+                $writer->addRow($this->createRow(array_values($values)));
             } else {
                 $writer->addRow(Row::fromValues($values));
             }
@@ -378,7 +383,7 @@ trait Exportable
         $row = [];
         foreach (is_array($data) ? $data : collect($data)->all() as $key => $value) {
             $value = is_null($value) ? '' : $this->formatValue($value, $key);
-            if (is_string($value) || is_int($value) || is_float($value) || $value instanceof DateTimeInterface) {
+            if (is_string($value) || is_int($value) || is_float($value) || $value instanceof DateTimeInterface || $value instanceof Cell) {
                 $row[$key] = $value;
             }
         }
@@ -457,6 +462,35 @@ trait Exportable
      */
     private function createRow(array $values = [], ?Style $rows_style = null, array $column_styles = []): Row
     {
-        return Row::fromValuesWithStyles($values, $rows_style, $column_styles);
+        // Fast path: no pre-built cells, let OpenSpout build them from scalars.
+        if (!$this->rowHasCell($values)) {
+            return Row::fromValuesWithStyles($values, $rows_style, $column_styles);
+        }
+
+        // A value is already a Cell: use it as-is and convert the remaining
+        // scalars, preserving any per-column style. Row::fromValuesWithStyles()
+        // cannot be used here because it calls Cell::fromValue() on every value.
+        $cells = [];
+        foreach ($values as $key => $value) {
+            $cells[] = $value instanceof Cell
+                ? $value
+                : Cell::fromValue($value, $column_styles[$key] ?? null);
+        }
+
+        return new Row($cells, $rows_style);
+    }
+
+    /**
+     * Whether any value in the given row is already an OpenSpout Cell instance.
+     */
+    private function rowHasCell(array $row): bool
+    {
+        foreach ($row as $value) {
+            if ($value instanceof Cell) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -2,6 +2,7 @@
 
 namespace Rap2hpoutre\FastExcel\Tests;
 
+use OpenSpout\Common\Entity\Cell;
 use OpenSpout\Common\Entity\Style\Color;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Common\Exception\IOException;
@@ -36,6 +37,61 @@ class FastExcelTest extends TestCase
             ->export($file);
 
         $this->assertEquals($collection, (new FastExcel())->import($file));
+        unlink($file);
+    }
+
+    /**
+     * A row value may be an OpenSpout Cell instance; it must be written
+     * through as-is instead of being dropped or stringified.
+     *
+     * @throws IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     */
+    public function testExportWithCellInstances()
+    {
+        $collection = collect([
+            ['col1' => Cell::fromValue('hello'), 'col2' => 'world'],
+            ['col1' => 'foo', 'col2' => Cell::fromValue('bar')],
+        ]);
+
+        $file = __DIR__.'/test-cell-instances.xlsx';
+        (new FastExcel(clone $collection))->export($file);
+
+        $this->assertEquals([
+            ['col1' => 'hello', 'col2' => 'world'],
+            ['col1' => 'foo', 'col2' => 'bar'],
+        ], (new FastExcel())->import($file)->toArray());
+        unlink($file);
+    }
+
+    /**
+     * Cell instances must also survive the styled export path (setColumnStyles).
+     *
+     * @throws IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     */
+    public function testExportWithCellInstancesAndColumnStyles()
+    {
+        $collection = collect([
+            ['col1' => Cell::fromValue('hello'), 'col2' => 'world'],
+        ]);
+
+        $file = __DIR__.'/test-cell-instances-styled.xlsx';
+        (new FastExcel(clone $collection))
+            ->setColumnStyles([
+                1 => (new Style())->setFontBold(),
+            ])
+            ->export($file);
+
+        $this->assertEquals([
+            ['col1' => 'hello', 'col2' => 'world'],
+        ], (new FastExcel())->import($file)->toArray());
         unlink($file);
     }
 


### PR DESCRIPTION
## What

Row values passed to `FastExcel` for export may now be
`OpenSpout\Common\Entity\Cell` instances (e.g. `Cell::fromValue('paid', $style)`
or a `StringCell`). The pre-built cell is written through **as-is**, giving
users full control over that cell's type and style, while the other (scalar)
values in the same row keep their normal handling and per-column styles.

Previously a `Cell` value was silently dropped by `transformRow()` and would
have broken `Row::fromValuesWithStyles()` / `Row::fromValues()`, which expect
scalars.

## Implementation (minimal & surgical)

- `transformRow()` preserves `Cell` instances instead of dropping them.
- `createRow()` builds the `Row` manually when any value is a `Cell` (using the
  existing cell directly and converting the remaining scalars via
  `Cell::fromValue($value, $columnStyles[$key] ?? null)` to keep per-column
  styles). When no value is a `Cell`, the existing `Row::fromValuesWithStyles`
  fast path is unchanged.
- The no-style fast path in `writeRowsFromCollection()` routes rows containing a
  `Cell` through `createRow()` (small `rowHasCell()` helper), since
  `Row::fromValues()` cannot accept `Cell` objects.

No unrelated refactoring. Header generation is unaffected.

## Tests

Added `testExportWithCellInstances` (mixed scalar + `Cell` row, round-trips to
`'hello'`/`'bar'`) and `testExportWithCellInstancesAndColumnStyles` (styled
export path). Full suite: 46 passing.

## Credit

Reimplements the core feature originally proposed by @kusab85 in #306. That PR
was a large stale rewrite against old code; its wholesale refactor was
intentionally dropped in favor of this small, surgical change on current
`master`.

Supersedes #306