### PR TITLE
bench: measure streaming export/import paths (fix peak-memory reporting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,20 +172,45 @@ Import multiple sheets with sheets names:
 $sheets = (new FastExcel)->withSheetsNames()->importSheets('file.xlsx');
 ```
 
-### Export large collections with chunk
+### Export large collections (low memory)
 
-Export rows one by one to avoid `memory_limit` issues [using `yield`](https://www.php.net/manual/en/language.generators.syntax.php):
+Passing a materialized collection (`User::all()`, `->get()`, `collect([...])`) loads every
+row into memory *before* the export starts, so it grows with the size of the data and a
+large enough dataset fails outright with `Allowed memory size of N bytes exhausted`. Feed a
+lazy source instead and peak memory stays flat, whatever the row count.
+
+Eloquent's `cursor()` (or `->lazy()`) returns a
+[`LazyCollection`](https://laravel.com/docs/collections#lazy-collections), which FastExcel
+streams row by row — no wrapper needed:
 
 ```php
-function usersGenerator() {
-    foreach (User::cursor() as $user) {
-        yield $user;
+// Export consumes only a few MB, even with 10M+ rows.
+(new FastExcel(User::cursor()))->export('users.xlsx');
+```
+
+For any other source, hand `export()` a generator [using `yield`](https://www.php.net/manual/en/language.generators.syntax.php):
+
+```php
+function rowsGenerator() {
+    foreach (some_paginated_source() as $row) {
+        yield $row;
     }
 }
 
-// Export consumes only a few MB, even with 10M+ rows.
-(new FastExcel(usersGenerator()))->export('test.xlsx');
+(new FastExcel(rowsGenerator()))->export('test.xlsx');
 ```
+
+Exporting 1,000,000 rows (4 columns) under a 512 MB `memory_limit`:
+
+| How you export | Peak memory | Result |
+| --- | --- | --- |
+| `export()` from a materialized collection | > 512 MB | **fails** once it exceeds `memory_limit` |
+| `export()` from a cursor / generator (streaming) | ~4 MB | always completes |
+
+Streaming does not change export *speed* (that is dominated by the underlying
+[OpenSpout](https://github.com/openspout/openspout) writer) — it is what keeps memory flat
+so very large files finish at all. `transpose()` cannot stream, as it must buffer the whole
+dataset to pivot rows and columns.
 
 ### Import large files (low memory)
 

--- a/bench/bench.php
+++ b/bench/bench.php
@@ -10,6 +10,13 @@
  * Reports the median wall-clock time and peak memory for the main
  * export/import paths. Memory numbers are stable across runs; time on
  * shared CI runners is noisy, so deltas under ~10% should be ignored.
+ *
+ * Peak memory is read with memory_get_peak_usage(false) — PHP's own
+ * allocator, which is released back between cases. The real (true) figure
+ * reports the process high-water mark from the OS allocator, which never
+ * shrinks, so a 4 MB streaming case measured after a 30 MB collection case
+ * would wrongly report ~30 MB. Using the PHP figure keeps every case honest
+ * in a single process.
  */
 
 use OpenSpout\Common\Entity\Style\Style;
@@ -29,6 +36,13 @@ $json = in_array('--json', $argv, true);
 $dir = sys_get_temp_dir().'/fastexcel-bench-'.getmypid();
 mkdir($dir);
 
+$style = (new Style())->setFontBold();
+
+$results = [];
+
+// The collection cases share one materialized collection (15 MB+ at 30k rows).
+// It is freed before the streaming cases so their peak memory reflects the
+// streaming path alone, not a leftover collection still held in scope.
 $collection = collect(array_map(fn ($i) => [
     'id'     => $i,
     'name'   => 'name_'.$i,
@@ -36,22 +50,34 @@ $collection = collect(array_map(fn ($i) => [
     'amount' => $i * 1.5,
 ], range(1, $rows)));
 
-$style = (new Style())->setFontBold();
+$results['export_plain'] = bench($runs, function () use ($collection, $dir) {
+    (new FastExcel($collection))->export($dir.'/plain.xlsx');
+});
+$results['export_styled'] = bench($runs, function () use ($collection, $dir, $style) {
+    (new FastExcel($collection))->headerStyle($style)->rowsStyle($style)->export($dir.'/styled.xlsx');
+});
 
-$results = [
-    'export_plain' => bench($runs, function () use ($collection, $dir) {
-        (new FastExcel($collection))->export($dir.'/plain.xlsx');
-    }),
-    'export_styled' => bench($runs, function () use ($collection, $dir, $style) {
-        (new FastExcel($collection))->headerStyle($style)->rowsStyle($style)->export($dir.'/styled.xlsx');
-    }),
-    'import' => bench($runs, function () use ($dir) {
-        (new FastExcel())->import($dir.'/plain.xlsx');
-    }),
-    'import_transposed' => bench($runs, function () use ($dir) {
-        (new FastExcel())->transpose()->import($dir.'/plain.xlsx');
-    }),
-];
+unset($collection);
+gc_collect_cycles();
+
+// Streaming export: a generator never materializes the full dataset, so peak
+// memory stays flat no matter how many rows are written.
+$results['export_generator'] = bench($runs, function () use ($rows, $dir) {
+    (new FastExcel(rowGenerator($rows)))->export($dir.'/gen.xlsx');
+});
+
+// Import cases read the file written by export_plain above.
+$results['import'] = bench($runs, function () use ($dir) {
+    (new FastExcel())->import($dir.'/plain.xlsx');
+});
+// Streaming import: importLazy() yields rows one at a time instead of
+// accumulating them into a Collection.
+$results['import_lazy'] = bench($runs, function () use ($dir) {
+    (new FastExcel())->importLazy($dir.'/plain.xlsx')->each(fn ($row) => $row);
+});
+$results['import_transposed'] = bench($runs, function () use ($dir) {
+    (new FastExcel())->transpose()->import($dir.'/plain.xlsx');
+});
 
 array_map('unlink', glob($dir.'/*'));
 rmdir($dir);
@@ -62,6 +88,22 @@ if ($json) {
     printf('%d rows, median of %d runs (PHP %s)%s', $rows, $runs, PHP_VERSION, PHP_EOL);
     foreach ($results as $name => $result) {
         printf('  %-18s %8.3fs  %8.1f MB peak%s', $name, $result['median_s'], $result['peak_mb'], PHP_EOL);
+    }
+}
+
+/**
+ * A fresh generator over the benchmark row shape. Generators are single-use,
+ * so each timed run needs a new one.
+ */
+function rowGenerator(int $rows): Generator
+{
+    for ($i = 1; $i <= $rows; $i++) {
+        yield [
+            'id'     => $i,
+            'name'   => 'name_'.$i,
+            'email'  => 'user'.$i.'@example.com',
+            'amount' => $i * 1.5,
+        ];
     }
 }
 
@@ -78,7 +120,7 @@ function bench(int $runs, callable $callback): array
         $start = hrtime(true);
         $callback();
         $times[] = (hrtime(true) - $start) / 1e9;
-        $peak = max($peak, memory_get_peak_usage(true));
+        $peak = max($peak, memory_get_peak_usage(false));
     }
 
     sort($times);


### PR DESCRIPTION
## What

The benchmark only exercised the memory-heavy paths (materialized `Collection` export, eager `import()`), so it never demonstrated the streaming advantage the docs already describe. This adds the streaming cases and fixes how peak memory is measured.

## The measurement fix

Peak memory was read with `memory_get_peak_usage(true)` — the process high-water mark from the OS allocator, which never shrinks. So a 4 MB streaming case measured *after* a 30 MB collection case wrongly reported ~30 MB. Reading `memory_get_peak_usage(false)` (PHP's own allocator, released between cases) reports each case honestly in a single process. The shared collection is also freed before the streaming cases so their peak reflects the streaming path alone.

## Changes

- Add `export_generator` and `import_lazy` benchmark cases.
- Switch peak-memory reads to `memory_get_peak_usage(false)`; free the materialized collection before the streaming cases.
- `--json` shape and `--compare` mode are unchanged; the benchmark workflow runs the PR's `bench.php` for both base and head, so the measurement method stays consistent on both sides.
- README: document passing `User::cursor()` / a `LazyCollection` directly to `export()` (no wrapper generator needed), with a 1M-row memory table and the streaming / `transpose()` caveats.

## Measured (30k rows, PHP 8.4.17)

| Case | Peak memory |
| --- | --- |
| export_plain (Collection) | 29 MB |
| **export_generator** | **3 MB** |
| import (eager) | 17 MB |
| **import_lazy** | **4 MB** |

At 1M rows a materialized collection export exceeds a 512 MB limit and fails, while the generator / `cursor()` path stays flat at a few MB.

## Note

This is **not** a runtime speed change — CPU time is dominated by OpenSpout and is unchanged. It is a benchmark-accuracy and memory-discoverability change: it makes the tool measure the path that turns a large-file OOM into a constant-memory job.