### PR TITLE
docs: document setting column widths via configureOptionsUsing (#213)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,37 @@ return (new FastExcel($list))
     ->download('file.xlsx');
 ```
 
+### Set column widths
+
+Column widths are an OpenSpout writer option, so they are set through
+`configureOptionsUsing`. Widths are expressed in Excel's own unit (roughly the
+number of characters that fit), and column numbers are **1-based**:
+
+```php
+(new FastExcel($list))
+    ->configureOptionsUsing(function ($options) {
+        $options->setColumnWidth(40, 1);      // first column
+        $options->setColumnWidth(15, 2, 3);   // second and third columns
+    })
+    ->export('file.xlsx');
+```
+
+Use `setColumnWidthForRange` for a contiguous span:
+
+```php
+(new FastExcel($list))
+    ->configureOptionsUsing(function ($options) {
+        $options->setColumnWidthForRange(20, 1, 4); // columns 1 through 4
+    })
+    ->export('file.xlsx');
+```
+
+This works with streaming exports (cursors and generators) as well, since widths
+are written when the file is finalized rather than per row. `xlsx` and `ods`
+support widths; `csv` has no notion of column width, so the option is ignored.
+
+Note that widths are explicit — there is no automatic sizing to fit the content.
+
 ### Export values as strings or numbers
 
 By default numbers are written as numbers and strings as strings. Use

--- a/README.md
+++ b/README.md
@@ -354,8 +354,20 @@ Use `setColumnWidthForRange` for a contiguous span:
 ```
 
 This works with streaming exports (cursors and generators) as well, since widths
-are written when the file is finalized rather than per row. `xlsx` and `ods`
-support widths; `csv` has no notion of column width, so the option is ignored.
+are written when the file is finalized rather than per row.
+
+Only `xlsx` and `ods` support widths. `csv` has no notion of column width, and
+`OpenSpout\Writer\CSV\Options` does not define `setColumnWidth()` at all — calling
+it on a csv export raises `Error: Call to undefined method`. If the same code path
+can export either format, guard the call:
+
+```php
+->configureOptionsUsing(function ($options) {
+    if (method_exists($options, 'setColumnWidth')) {
+        $options->setColumnWidth(40, 1);
+    }
+})
+```
 
 Note that widths are explicit — there is no automatic sizing to fit the content.
 


### PR DESCRIPTION
## Why

#213 ("Auto size Excel column width") has been open since 2021 with 7 comments, and the answer on the thread is that widths are not possible. That is only half true: **explicit** column widths already work through OpenSpout's writer options and `configureOptionsUsing()` — it was simply never documented. Several commenters were asking for exactly this.

## Change

Docs only, no code. Adds an "Set column widths" section under Advanced usage covering:

- `setColumnWidth(width, ...$columns)` and `setColumnWidthForRange(width, $start, $end)`
- that column numbers are **1-based**
- that it works with **streaming** exports (cursor/generator), because widths are written when the file is finalized rather than per row
- that `xlsx`/`ods` support widths and `csv` ignores them
- an explicit note that automatic sizing to fit content is still unavailable

## Verified

Every snippet was run before being documented:

| Snippet | Result |
| --- | --- |
| `setColumnWidth(40, 1)` + `setColumnWidth(15, 2, 3)` | `<col min="1" max="1" width="40"/><col min="2" max="3" width="15"/>` |
| `setColumnWidthForRange(20, 1, 4)` | `<col min="1" max="4" width="20"/>` |
| same, from a generator (streaming) | `<col min="1" max="1" width="33"/>` |
| `ods` export | writes successfully |

Refs #213 — deliberately not "Closes", since auto-sizing is the actual request and remains open.
