### PR TITLE
feat: read headers from a specific row with headerRow() (#349)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,29 @@ Limit the number of data rows imported with `limitRows` (headers excluded). It w
 $collection = (new FastExcel)->limitRows(100)->import('file.xlsx');
 ```
 
+Start reading at a given row with `startRow`. On its own, `startRow` also treats
+that row as the header row. Use `headerRow` to read the headers from their real
+position while data starts further down:
+
+```php
+// Headers from row 1, data from row 155 onwards.
+$collection = (new FastExcel)->headerRow(1)->startRow(155)->import('file.xlsx');
+```
+
+Together with `limitRows`, that is how a large file is imported in chunks — one
+slice per job run, each with the correct header names:
+
+```php
+$chunk = (new FastExcel)
+    ->headerRow(1)
+    ->startRow(2 + ($page * 1000)) // data begins on row 2
+    ->limitRows(1000)
+    ->import('file.xlsx');
+```
+
+`headerRow` is opt-in: without it, `startRow` keeps its previous behaviour of
+using the start row as the header row.
+
 ## Facades
 
 You may use FastExcel with the optional Facade. Add the following line to ``config/app.php`` under the ``aliases`` key.

--- a/src/Facades/FastExcel.php
+++ b/src/Facades/FastExcel.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Illuminate\Support\Collection   import($path, callable $callback = null)
  * @method static string                           export($path, callable $callback = null)
  * @method static \Illuminate\Support\Collection   importSheets($path, callable $callback = null)
+ * @method static \Rap2hpoutre\FastExcel\FastExcel headerRow(?int $row = 1)
  * @method static \Rap2hpoutre\FastExcel\FastExcel limitRows(?int $rows = null)
  * @method static \Rap2hpoutre\FastExcel\FastExcel hideColumnsPrefixedWith($prefix = '_')
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureCsv($delimiter = ',', $enclosure = '"', $encoding = 'UTF-8', $bom = false)

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -39,6 +39,11 @@ class FastExcel
     /**
      * @var int|null
      */
+    private $header_row = null;
+
+    /**
+     * @var int|null
+     */
     private $end_row = null;
 
     /**
@@ -128,6 +133,28 @@ class FastExcel
     public function startRow(int $row)
     {
         $this->start_row = $row;
+
+        return $this;
+    }
+
+    /**
+     * Read the headers from a specific row instead of from startRow().
+     *
+     * By default `startRow(155)` also takes the headers from row 155. Set the
+     * header row explicitly to keep the real headers while reading data further
+     * down the file, which is what makes chunked imports possible:
+     *
+     *     (new FastExcel)->headerRow(1)->startRow(155)->limitRows(100)->import($file);
+     *
+     * Pass null to go back to taking the headers from startRow().
+     *
+     * @param int|null $row 1-based row index
+     *
+     * @return $this
+     */
+    public function headerRow(?int $row = 1)
+    {
+        $this->header_row = $row;
 
         return $this;
     }

--- a/src/Importable.php
+++ b/src/Importable.php
@@ -12,6 +12,7 @@ use OpenSpout\Writer\Common\AbstractOptions;
  * Trait Importable.
  *
  * @property int  $start_row
+ * @property ?int $header_row
  * @property ?int $end_row
  * @property bool $transpose
  * @property bool $with_header
@@ -357,11 +358,44 @@ trait Importable
     }
 
     /**
+     * The 1-based index of the row holding the headers.
+     *
+     * Defaults to start_row, which is the historical behaviour: starting at row
+     * N also takes the headers from row N. headerRow() decouples the two so the
+     * headers can be read from their real position while data starts further
+     * down the file.
+     *
+     * @return int
+     */
+    private function headerRowIndex(): int
+    {
+        return $this->header_row ?? $this->start_row;
+    }
+
+    /**
+     * The 1-based index of the first row treated as data.
+     *
+     * The header row is never data, so when headers are enabled the first data
+     * row is at least the row after them — even if start_row points at or above
+     * the header row.
+     *
+     * @return int
+     */
+    private function firstDataRowIndex(): int
+    {
+        if (!$this->with_header) {
+            return $this->start_row;
+        }
+
+        return max($this->start_row, $this->headerRowIndex() + 1);
+    }
+
+    /**
      * Normalize a row according to start_row and headers.
      * - Updates $headers and $count_header when encountering header row.
      * - Pads/truncates rows to header size when headers exist.
      * - Returns combined associative row when headers exist, or the raw row when not.
-     * - Returns null to skip processing (before start_row or header row itself).
+     * - Returns null to skip processing (header row itself, or any row that is not data).
      *
      * @param int   $key
      * @param array $row
@@ -372,18 +406,20 @@ trait Importable
      */
     private function normalizeRow(int $key, array $row, array &$headers, int &$count_header): ?array
     {
-        if ($key < $this->start_row) {
+        // Capture the header row before the data-range check: with headerRow()
+        // it can sit above start_row, so it must not be skipped as "too early".
+        if ($this->with_header && $key === $this->headerRowIndex()) {
+            $headers = $this->uniqueHeaders($this->toStrings($row));
+            $count_header = count($headers);
+
+            return null; // skip header row
+        }
+
+        if ($key < $this->firstDataRowIndex()) {
             return null;
         }
 
         if ($this->with_header) {
-            if ($key == $this->start_row) {
-                $headers = $this->uniqueHeaders($this->toStrings($row));
-                $count_header = count($headers);
-
-                return null; // skip header row
-            }
-
             if ($count_header > $count_row = count($row)) {
                 $row = array_merge($row, array_fill(0, $count_header - $count_row, null));
             } elseif ($count_header < $count_row = count($row)) {

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -545,4 +545,110 @@ class IssuesTest extends TestCase
         $this->assertInstanceOf(Collection::class, $rows);
         $this->assertEquals($this->collection(), $rows);
     }
+
+    /**
+     * Issue #349: startRow() alone also takes the headers from the start row, so
+     * reading a file from row N loses the real headers (row N's data is used as
+     * the header names). headerRow() decouples the two.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     */
+    public function testIssue349HeaderRowSeparateFromStartRow()
+    {
+        // Row 1 holds the headers; rows 2..6 hold data 1..5.
+        $file = __DIR__.'/issue349.xlsx';
+        (new FastExcel($this->issue349Rows()))->export($file);
+
+        // Headers from row 1, data from row 4 (i.e. data 3, 4 and 5).
+        $rows = (new FastExcel())->headerRow(1)->startRow(4)->import($file);
+        $this->assertSame(['name', 'qty'], array_keys($rows->first()));
+        $this->assertSame(
+            [['name' => 'c', 'qty' => '3'], ['name' => 'd', 'qty' => '4'], ['name' => 'e', 'qty' => '5']],
+            $rows->toArray()
+        );
+
+        unlink($file);
+    }
+
+    /**
+     * headerRow() is what makes chunked imports work: each run reads the same
+     * headers but a different slice of data rows, with no overlap.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     */
+    public function testIssue349ChunkedImportWithLimitRows()
+    {
+        $file = __DIR__.'/issue349_chunks.xlsx';
+        (new FastExcel($this->issue349Rows()))->export($file);
+
+        $chunks = [];
+        // Data starts on row 2, so chunk k starts at row 2 + (k * size).
+        foreach ([2, 4, 6] as $start) {
+            $chunks[] = (new FastExcel())->headerRow(1)->startRow($start)->limitRows(2)->import($file)->toArray();
+        }
+
+        $this->assertSame([['name' => 'a', 'qty' => '1'], ['name' => 'b', 'qty' => '2']], $chunks[0]);
+        $this->assertSame([['name' => 'c', 'qty' => '3'], ['name' => 'd', 'qty' => '4']], $chunks[1]);
+        $this->assertSame([['name' => 'e', 'qty' => '5']], $chunks[2]);
+
+        // Every data row appears exactly once across the chunks.
+        $this->assertCount(5, array_merge(...$chunks));
+
+        // The lazy path honours it identically.
+        $lazy = (new FastExcel())->headerRow(1)->startRow(4)->limitRows(2)->importLazy($file)->all();
+        $this->assertSame($chunks[1], $lazy);
+
+        unlink($file);
+    }
+
+    /**
+     * Without headerRow(), startRow() keeps its historical meaning: the start
+     * row is also the header row. This must not change.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\InvalidArgumentException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     */
+    public function testIssue349StartRowBackwardCompatibility()
+    {
+        $file = __DIR__.'/issue349_bc.xlsx';
+        (new FastExcel($this->issue349Rows()))->export($file);
+
+        // Row 3 is data ('b', '2') and is still consumed as the header row.
+        $rows = (new FastExcel())->startRow(3)->import($file);
+        // '2' becomes int 2: PHP casts numeric-string array keys.
+        $this->assertSame(['b', 2], array_keys($rows->first()));
+        $this->assertSame([['b' => 'c', '2' => '3'], ['b' => 'd', '2' => '4'], ['b' => 'e', '2' => '5']], $rows->toArray());
+
+        // headerRow(null) explicitly restores that behaviour too.
+        $rows = (new FastExcel())->headerRow(null)->startRow(3)->import($file);
+        // '2' becomes int 2: PHP casts numeric-string array keys.
+        $this->assertSame(['b', 2], array_keys($rows->first()));
+
+        unlink($file);
+    }
+
+    /**
+     * Five data rows under a single header row, used by the #349 tests.
+     */
+    private function issue349Rows(): Collection
+    {
+        return collect([
+            ['name' => 'a', 'qty' => '1'],
+            ['name' => 'b', 'qty' => '2'],
+            ['name' => 'c', 'qty' => '3'],
+            ['name' => 'd', 'qty' => '4'],
+            ['name' => 'e', 'qty' => '5'],
+        ]);
+    }
 }


### PR DESCRIPTION
## Problem

`startRow(N)` also treats row N as the **header** row. So reading a file from row 155 takes the header names from row 155's *data*. Reproduced on `tests/test1.xlsx` (real headers `col1`,`col2` on row 1):

```php
(new FastExcel)->startRow(3)->import('test1.xlsx');
// => [{"row2 col1": "row3 col1", "column_2": "row3 col2"}]
//     ^ header names came from row 3's data
```

That is what @MaarekVarres reported in #349, and it is what makes **chunked imports impossible**: only the first chunk has usable keys. Since `limitRows()` shipped in v5.13.0 (#413), this is the one thing standing between `startRow` + `limitRows` and resumable imports.

## Change

Adds an opt-in `headerRow(?int $row = 1)`:

```php
// Headers from row 1, data from row 155 onwards.
(new FastExcel)->headerRow(1)->startRow(155)->import('file.xlsx');
```

Two small helpers in `Importable` carry the logic:

- `headerRowIndex()` — `header_row ?? start_row`, so the default is exactly today's behaviour.
- `firstDataRowIndex()` — `max(start_row, header_row + 1)` when headers are on, so the header row is **never** returned as data.

The header row is captured *before* the data-range check, because with `headerRow(1)->startRow(155)` it sits above `start_row` and would otherwise be skipped as "too early". Both `import()` and `importLazy()` go through `normalizeRow()`, so the eager and lazy paths behave identically.

`headerRow()` is the reporter's own fix generalised: their patch special-cased `$k === 1`, this takes any row and stays opt-in.

## Backwards compatibility

Unchanged unless you call `headerRow()`. `testIssue349StartRowBackwardCompatibility` pins the old meaning — `startRow(3)` still consumes row 3 as the header — and checks `headerRow(null)` restores it explicitly.

## Tests

Three new tests (57 passing, was 54):

- `testIssue349HeaderRowSeparateFromStartRow` — headers from row 1, data from row 4.
- `testIssue349ChunkedImportWithLimitRows` — three chunks of 2 over 5 data rows, asserts correct headers per chunk, no overlap, every row exactly once, and that `importLazy()` returns the same slice.
- `testIssue349StartRowBackwardCompatibility` — the BC guard above.

Edge cases exercised by hand: header row *below* `start_row` (stays consistent, never leaks raw rows), `withoutHeaders()` (setting ignored), `startRow` past EOF (empty), `headerRow == startRow` (identical to default), and `transpose()`.

The README chunking snippet was run against a 2,500-row file: 1000 / 1000 / 500 across three pages, all 2,500 ids unique and contiguous.

Refs #349
