### PR TITLE
feat: limit and allowlist import columns with limitColumns()/onlyColumns() (#370)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,31 @@ Limit the number of data rows imported with `limitRows` (headers excluded). It w
 $collection = (new FastExcel)->limitRows(100)->import('file.xlsx');
 ```
 
+Truncate each imported row after a given column with `limitColumns`, which takes
+either a column reference or a number of columns:
+
+```php
+$collection = (new FastExcel)->limitColumns('H')->import('file.xlsx');
+$collection = (new FastExcel)->limitColumns(8)->import('file.xlsx');
+```
+
+This is useful for files where formatting has been applied to entire rows: the
+spreadsheet then reports thousands of trailing cells that look like real columns,
+and importing them yields empty `column_9`, `column_10`… entries on every row.
+Those cells are dropped from the imported collection (OpenSpout still parses the
+sheet). Like `limitRows`, it works with both `import` and `importLazy`.
+
+Keep specific columns (and drop everything else, including middle empties) with
+`onlyColumns`. Letters and 1-based indexes can be mixed; order is preserved:
+
+```php
+$collection = (new FastExcel)->onlyColumns(['A', 'B', 'H'])->import('file.xlsx');
+$collection = (new FastExcel)->onlyColumns([1, 2, 8])->import('file.xlsx');
+```
+
+`onlyColumns` and `limitColumns` cannot both be active — setting one clears the other.
+Passing `null` only clears that setter and leaves the other alone.
+
 ## Facades
 
 You may use FastExcel with the optional Facade. Add the following line to ``config/app.php`` under the ``aliases`` key.

--- a/src/Facades/FastExcel.php
+++ b/src/Facades/FastExcel.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static string                           export($path, callable $callback = null)
  * @method static \Illuminate\Support\Collection   importSheets($path, callable $callback = null)
  * @method static \Rap2hpoutre\FastExcel\FastExcel limitRows(?int $rows = null)
+ * @method static \Rap2hpoutre\FastExcel\FastExcel limitColumns(int|string|null $column = null)
+ * @method static \Rap2hpoutre\FastExcel\FastExcel onlyColumns(?array $columns = null)
  * @method static \Rap2hpoutre\FastExcel\FastExcel hideColumnsPrefixedWith($prefix = '_')
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureCsv($delimiter = ',', $enclosure = '"', $encoding = 'UTF-8', $bom = false)
  * @method static \Rap2hpoutre\FastExcel\FastExcel configureReaderUsing(?callable $callback = null)

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -204,10 +204,13 @@ class FastExcel
         }
 
         $this->end_column = null;
-        $indexes = array_values(array_map(
-            fn ($column) => $this->columnIndex($column),
-            $columns
-        ));
+        $indexes = array_values(array_map(function ($column) {
+            if (!is_int($column) && !is_string($column)) {
+                throw new InvalidArgumentException('onlyColumns() accepts column letters or 1-based indexes.');
+            }
+
+            return $this->columnIndex($column);
+        }, $columns));
 
         if (count($indexes) !== count(array_unique($indexes))) {
             throw new InvalidArgumentException('onlyColumns() does not allow duplicate columns.');

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -230,20 +230,21 @@ class FastExcel
     {
         if (is_int($column) || ctype_digit($column)) {
             $index = (int) $column;
-        } else {
-            $letters = strtoupper(trim($column));
-            if ($letters === '' || !ctype_alpha($letters)) {
-                throw new InvalidArgumentException("Invalid column reference [$column].");
+            if ($index < 1) {
+                throw new InvalidArgumentException("Column reference [$column] must be greater than zero.");
             }
 
-            $index = 0;
-            foreach (str_split($letters) as $letter) {
-                $index = $index * 26 + ord($letter) - ord('A') + 1;
-            }
+            return $index;
         }
 
-        if ($index < 1) {
-            throw new InvalidArgumentException("Column reference [$column] must be greater than zero.");
+        $letters = strtoupper(trim($column));
+        if ($letters === '' || !ctype_alpha($letters)) {
+            throw new InvalidArgumentException("Invalid column reference [$column].");
+        }
+
+        $index = 0;
+        foreach (str_split($letters) as $letter) {
+            $index = $index * 26 + ord($letter) - ord('A') + 1;
         }
 
         return $index;

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -3,6 +3,7 @@
 namespace Rap2hpoutre\FastExcel;
 
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use OpenSpout\Reader\CSV\Options as CsvReaderOptions;
 use OpenSpout\Writer\Common\AbstractOptions;
 use OpenSpout\Writer\CSV\Options as CsvWriterOptions;
@@ -40,6 +41,18 @@ class FastExcel
      * @var int|null
      */
     private $end_row = null;
+
+    /**
+     * @var int|null
+     */
+    private $end_column = null;
+
+    /**
+     * 1-based column indexes to keep when importing. Null means no allowlist.
+     *
+     * @var int[]|null
+     */
+    private $only_columns = null;
 
     /**
      * @var bool
@@ -144,6 +157,96 @@ class FastExcel
         $this->end_row = $rows;
 
         return $this;
+    }
+
+    /**
+     * Stop reading each row after the given column, given either as a number of
+     * columns (8) or as a column reference ('H'). Pass null to remove the limit.
+     * Setting a limit clears any onlyColumns() allowlist; clearing with null does not.
+     *
+     * @param int|string|null $column
+     *
+     * @return $this
+     */
+    public function limitColumns(int|string|null $column = null)
+    {
+        if ($column === null) {
+            $this->end_column = null;
+
+            return $this;
+        }
+
+        $this->only_columns = null;
+        $this->end_column = $this->columnIndex($column);
+
+        return $this;
+    }
+
+    /**
+     * Keep only the given columns when importing (letters or 1-based indexes).
+     * Order is preserved. Pass null to clear the allowlist.
+     * Setting an allowlist clears any limitColumns() cap; clearing with null does not.
+     *
+     * @param array<int, int|string>|null $columns
+     *
+     * @return $this
+     */
+    public function onlyColumns(?array $columns = null)
+    {
+        if ($columns === null) {
+            $this->only_columns = null;
+
+            return $this;
+        }
+
+        if ($columns === []) {
+            throw new InvalidArgumentException('onlyColumns() requires at least one column.');
+        }
+
+        $this->end_column = null;
+        $indexes = array_values(array_map(
+            fn ($column) => $this->columnIndex($column),
+            $columns
+        ));
+
+        if (count($indexes) !== count(array_unique($indexes))) {
+            throw new InvalidArgumentException('onlyColumns() does not allow duplicate columns.');
+        }
+
+        $this->only_columns = $indexes;
+
+        return $this;
+    }
+
+    /**
+     * Resolve a column reference to its 1-based index: both 8 and 'H' give 8,
+     * 'AA' gives 27.
+     *
+     * @param int|string $column
+     *
+     * @return int
+     */
+    private function columnIndex(int|string $column)
+    {
+        if (is_int($column) || ctype_digit($column)) {
+            $index = (int) $column;
+        } else {
+            $letters = strtoupper(trim($column));
+            if ($letters === '' || !ctype_alpha($letters)) {
+                throw new InvalidArgumentException("Invalid column reference [$column].");
+            }
+
+            $index = 0;
+            foreach (str_split($letters) as $letter) {
+                $index = $index * 26 + ord($letter) - ord('A') + 1;
+            }
+        }
+
+        if ($index < 1) {
+            throw new InvalidArgumentException("Column reference [$column] must be greater than zero.");
+        }
+
+        return $index;
     }
 
     /**

--- a/src/Importable.php
+++ b/src/Importable.php
@@ -5,6 +5,7 @@ namespace Rap2hpoutre\FastExcel;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use OpenSpout\Common\Entity\Cell;
+use OpenSpout\Common\Entity\Row;
 use OpenSpout\Reader\SheetInterface;
 use OpenSpout\Writer\Common\AbstractOptions;
 
@@ -13,6 +14,8 @@ use OpenSpout\Writer\Common\AbstractOptions;
  *
  * @property int  $start_row
  * @property ?int $end_row
+ * @property ?int $end_column
+ * @property int[]|null $only_columns
  * @property bool $transpose
  * @property bool $with_header
  */
@@ -332,6 +335,47 @@ trait Importable
     }
 
     /**
+     * Read the values of a row, optionally filtered by only_columns or end_column.
+     *
+     * only_columns picks specific positions (and can skip a middle gap).
+     * end_column truncates after a given column. Filtering happens before values
+     * are read so trailing formatted-empty cells are not materialised.
+     *
+     * @param Row $rowAsObject
+     *
+     * @return array
+     */
+    private function rowValues(Row $rowAsObject): array
+    {
+        $cells = $rowAsObject->getCells();
+
+        if ($this->only_columns !== null) {
+            return array_map(function (int $column) use ($cells) {
+                $cell = $cells[$column - 1] ?? null;
+                if ($cell === null) {
+                    return null;
+                }
+
+                return match (true) {
+                    $cell instanceof Cell\FormulaCell => $cell->getComputedValue(),
+                    default => $cell->getValue(),
+                };
+            }, $this->only_columns);
+        }
+
+        if ($this->end_column !== null) {
+            $cells = array_slice($cells, 0, $this->end_column);
+        }
+
+        return array_map(function (Cell $cell) {
+            return match (true) {
+                $cell instanceof Cell\FormulaCell => $cell->getComputedValue(),
+                default => $cell->getValue(),
+            };
+        }, $cells);
+    }
+
+    /**
      * Normalize a row according to start_row and headers.
      * - Updates $headers and $count_header when encountering header row.
      * - Pads/truncates rows to header size when headers exist.
@@ -383,14 +427,7 @@ trait Importable
         $count_rows = 0;
 
         foreach ($sheet->getRowIterator() as $key => $rowAsObject) {
-            $row = array_map(function (Cell $cell) {
-                return match (true) {
-                    $cell instanceof Cell\FormulaCell => $cell->getComputedValue(),
-                    default                           => $cell->getValue(),
-                };
-            }, $rowAsObject->getCells());
-
-            $current = $this->normalizeRow($key, $row, $headers, $count_header);
+            $current = $this->normalizeRow($key, $this->rowValues($rowAsObject), $headers, $count_header);
             if ($current === null) {
                 continue;
             }
@@ -430,14 +467,7 @@ trait Importable
         $count_rows = 0;
 
         foreach ($sheet->getRowIterator() as $key => $rowAsObject) {
-            $row = array_map(function (Cell $cell) {
-                return match (true) {
-                    $cell instanceof Cell\FormulaCell => $cell->getComputedValue(),
-                    default                           => $cell->getValue(),
-                };
-            }, $rowAsObject->getCells());
-
-            $current = $this->normalizeRow($key, $row, $headers, $count_header);
+            $current = $this->normalizeRow($key, $this->rowValues($rowAsObject), $headers, $count_header);
             if ($current === null) {
                 continue;
             }
@@ -477,10 +507,10 @@ trait Importable
 
     /**
      * Make header names usable as array keys. Empty headers get a positional
-     * name (`column_N`) and duplicated headers are de-duplicated: the first
-     * occurrence is kept and later ones get a numeric suffix (`Name`, `Name_2`).
-     * Without this, columns that share a name collide in array_combine() and
-     * their values are silently lost.
+     * name (`column_N`, using the sheet column number) and duplicated headers
+     * are de-duplicated: the first occurrence is kept and later ones get a
+     * numeric suffix (`Name`, `Name_2`). Without this, columns that share a
+     * name collide in array_combine() and their values are silently lost.
      *
      * @param array $headers
      *
@@ -492,7 +522,10 @@ trait Importable
         foreach ($headers as $index => $header) {
             $header = (string) $header;
             if ($header === '') {
-                $header = 'column_'.($index + 1);
+                // Prefer the original sheet column (1-based) when an allowlist
+                // remapped positions, so onlyColumns(['B']) yields column_2.
+                $columnNumber = $this->only_columns[$index] ?? ($index + 1);
+                $header = 'column_'.$columnNumber;
             }
 
             $base = $header;

--- a/src/Importable.php
+++ b/src/Importable.php
@@ -12,12 +12,12 @@ use OpenSpout\Writer\Common\AbstractOptions;
 /**
  * Trait Importable.
  *
- * @property int  $start_row
- * @property ?int $end_row
- * @property ?int $end_column
+ * @property int        $start_row
+ * @property ?int       $end_row
+ * @property ?int       $end_column
  * @property int[]|null $only_columns
- * @property bool $transpose
- * @property bool $with_header
+ * @property bool       $transpose
+ * @property bool       $with_header
  */
 trait Importable
 {
@@ -358,7 +358,7 @@ trait Importable
 
                 return match (true) {
                     $cell instanceof Cell\FormulaCell => $cell->getComputedValue(),
-                    default => $cell->getValue(),
+                    default                           => $cell->getValue(),
                 };
             }, $this->only_columns);
         }
@@ -370,7 +370,7 @@ trait Importable
         return array_map(function (Cell $cell) {
             return match (true) {
                 $cell instanceof Cell\FormulaCell => $cell->getComputedValue(),
-                default => $cell->getValue(),
+                default                           => $cell->getValue(),
             };
         }, $cells);
     }

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -570,4 +570,334 @@ class FastExcelTest extends TestCase
             ['col1' => 'row2 col1', 'col2' => ''],
         ]), $collection);
     }
+
+    /**
+     * Formatting applied past the data makes the reader report trailing columns
+     * that hold nothing, and they end up as positional headers on every row.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testImportWithoutLimitColumnsKeepsFormattedEmptyColumns()
+    {
+        $collection = (new FastExcel())->import($this->createFileWithFormattedEmptyColumns());
+
+        $this->assertEquals(
+            ['col1', 'col2', 'column_3', 'column_4', 'column_5'],
+            array_keys($collection->first())
+        );
+    }
+
+    /**
+     * limitColumns() drops those columns, whether given as a reference or a count.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testImportWithLimitColumns()
+    {
+        $file = $this->createFileWithFormattedEmptyColumns();
+
+        $expected = collect([
+            ['col1' => 'row1 col1', 'col2' => 'row1 col2'],
+            ['col1' => 'row2 col1', 'col2' => 'row2 col2'],
+        ]);
+
+        $this->assertEquals($expected, (new FastExcel())->limitColumns('B')->import($file));
+        $this->assertEquals($expected, (new FastExcel())->limitColumns(2)->import($file));
+    }
+
+    /**
+     * A limit wider than the sheet, and limitColumns(null), leave the row untouched.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testImportWithLimitColumnsWiderThanSheet()
+    {
+        $this->assertEquals($this->collection(), (new FastExcel())->limitColumns('Z')->import(__DIR__.'/test1.xlsx'));
+        $this->assertEquals($this->collection(), (new FastExcel())->limitColumns(null)->import(__DIR__.'/test1.xlsx'));
+    }
+
+    /**
+     * Column references past Z resolve to their real position: 'AA' is the 27th.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testImportWithMultiLetterLimitColumns()
+    {
+        $collection = (new FastExcel())->limitColumns('AA')->import(
+            $this->createFileWithFormattedEmptyColumns(40)
+        );
+
+        $this->assertCount(27, $collection->first());
+        $this->assertEquals('column_27', array_key_last($collection->first()));
+    }
+
+    /**
+     * The lazy import path honors limitColumns() identically to the eager path.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testImportLazyWithLimitColumns()
+    {
+        $collection = (new FastExcel())
+            ->limitColumns('B')
+            ->importLazy($this->createFileWithFormattedEmptyColumns())
+            ->collect();
+
+        $this->assertEquals(collect([
+            ['col1' => 'row1 col1', 'col2' => 'row1 col2'],
+            ['col1' => 'row2 col1', 'col2' => 'row2 col2'],
+        ]), $collection);
+    }
+
+    /**
+     * Anything that is neither a positive count nor a column reference is rejected.
+     */
+    public function testLimitColumnsRejectsInvalidReferences()
+    {
+        foreach ([0, -1, '', 'A1', '-'] as $column) {
+            try {
+                (new FastExcel())->limitColumns($column);
+                $this->fail("Expected [$column] to be rejected.");
+            } catch (\InvalidArgumentException $e) {
+                $this->assertStringContainsString("[$column]", $e->getMessage());
+            }
+        }
+    }
+
+    /**
+     * onlyColumns() keeps an allowlist and can skip a middle band of empties.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testImportWithOnlyColumnsSkipsMiddleEmpties()
+    {
+        $collection = (new FastExcel())
+            ->onlyColumns(['A', 'B', 'H'])
+            ->import($this->createFileWithMiddleEmptyColumnsAndTrailingData());
+
+        $this->assertEquals(collect([
+            ['col1' => 'row1 col1', 'col2' => 'row1 col2', 'extra' => 'h1'],
+            ['col1' => 'row2 col1', 'col2' => 'row2 col2', 'extra' => 'h2'],
+        ]), $collection);
+    }
+
+    /**
+     * onlyColumns() preserves allowlist order and accepts 1-based indexes.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testImportWithOnlyColumnsPreservesOrder()
+    {
+        $collection = (new FastExcel())
+            ->onlyColumns([8, 1])
+            ->import($this->createFileWithMiddleEmptyColumnsAndTrailingData());
+
+        $this->assertEquals(collect([
+            ['extra' => 'h1', 'col1' => 'row1 col1'],
+            ['extra' => 'h2', 'col1' => 'row2 col1'],
+        ]), $collection);
+    }
+
+    /**
+     * The lazy import path honors onlyColumns() identically to the eager path.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testImportLazyWithOnlyColumns()
+    {
+        $collection = (new FastExcel())
+            ->onlyColumns(['A', 'H'])
+            ->importLazy($this->createFileWithMiddleEmptyColumnsAndTrailingData())
+            ->collect();
+
+        $this->assertEquals(collect([
+            ['col1' => 'row1 col1', 'extra' => 'h1'],
+            ['col1' => 'row2 col1', 'extra' => 'h2'],
+        ]), $collection);
+    }
+
+    public function testOnlyColumnsRejectsEmptyAllowlist()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new FastExcel())->onlyColumns([]);
+    }
+
+    public function testOnlyColumnsRejectsDuplicates()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('duplicate');
+
+        (new FastExcel())->onlyColumns(['A', 'A']);
+    }
+
+    /**
+     * Empty headers keep the sheet column number after an allowlist remap.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testOnlyColumnsEmptyHeaderUsesSheetColumnNumber()
+    {
+        $file = $this->tempXlsx('empty-header-b');
+        $writer = new \OpenSpout\Writer\XLSX\Writer();
+        $writer->openToFile($file);
+        $writer->addRow(\OpenSpout\Common\Entity\Row::fromValues(['name', '', 'x']));
+        $writer->addRow(\OpenSpout\Common\Entity\Row::fromValues(['alice', 'ignored', '1']));
+        $writer->close();
+
+        $row = (new FastExcel())->onlyColumns(['B'])->import($file)->first();
+
+        $this->assertSame(['column_2'], array_keys($row));
+        $this->assertSame('ignored', $row['column_2']);
+    }
+
+    /**
+     * onlyColumns() and limitColumns() cannot both be active — setting one clears the other.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testOnlyColumnsAndLimitColumnsLastCallWins()
+    {
+        $file = $this->createFileWithMiddleEmptyColumnsAndTrailingData();
+
+        $withOnly = (new FastExcel())
+            ->limitColumns('B')
+            ->onlyColumns(['A', 'H'])
+            ->import($file);
+
+        $this->assertEquals(['col1', 'extra'], array_keys($withOnly->first()));
+
+        $withLimit = (new FastExcel())
+            ->onlyColumns(['A', 'H'])
+            ->limitColumns('B')
+            ->import($file);
+
+        $this->assertEquals(['col1', 'col2'], array_keys($withLimit->first()));
+    }
+
+    /**
+     * Clearing with null only unsets that setter — it must not wipe the other mode.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testClearingOneColumnFilterLeavesTheOther()
+    {
+        $file = $this->createFileWithMiddleEmptyColumnsAndTrailingData();
+
+        $keptAllowlist = (new FastExcel())
+            ->onlyColumns(['A', 'H'])
+            ->limitColumns(null)
+            ->import($file);
+
+        $this->assertEquals(['col1', 'extra'], array_keys($keptAllowlist->first()));
+
+        $keptLimit = (new FastExcel())
+            ->limitColumns('B')
+            ->onlyColumns(null)
+            ->import($file);
+
+        $this->assertEquals(['col1', 'col2'], array_keys($keptLimit->first()));
+    }
+
+    /**
+     * onlyColumns() reindexes the allowlist so sparse input keys do not leak into rows.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Common\Exception\UnsupportedTypeException
+     * @throws \OpenSpout\Reader\Exception\ReaderNotOpenedException
+     */
+    public function testOnlyColumnsReindexesSparseAllowlistKeys()
+    {
+        $row = (new FastExcel())
+            ->withoutHeaders()
+            ->onlyColumns([2 => 'A', 9 => 'H'])
+            ->import($this->createFileWithMiddleEmptyColumnsAndTrailingData())
+            ->first();
+
+        $this->assertSame([0, 1], array_keys($row));
+        $this->assertEquals(['col1', 'extra'], $row);
+    }
+
+    /**
+     * Write a sheet whose two data columns are followed by empty cells that exist
+     * only because a background fill was applied to them. Spreadsheet software
+     * records formatting this way, and unstyled empty cells are not written at all.
+     *
+     * @param int $empty_columns
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     *
+     * @return string
+     */
+    private function createFileWithFormattedEmptyColumns($empty_columns = 3)
+    {
+        $file = $this->tempXlsx('formatted-empty');
+        $styles = array_fill(2, $empty_columns, (new Style())->setBackgroundColor(Color::YELLOW));
+
+        $writer = new \OpenSpout\Writer\XLSX\Writer();
+        $writer->openToFile($file);
+        foreach ([['col1', 'col2'], ['row1 col1', 'row1 col2'], ['row2 col1', 'row2 col2']] as $values) {
+            $writer->addRow(\OpenSpout\Common\Entity\Row::fromValuesWithStyles(
+                array_merge($values, array_fill(2, $empty_columns, '')),
+                null,
+                $styles
+            ));
+        }
+        $writer->close();
+
+        return $file;
+    }
+
+    /**
+     * A–B have data, C–G are yellow-filled empties, H has trailing data — the
+     * layout onlyColumns() is meant to handle by skipping the middle gap.
+     *
+     * @throws \OpenSpout\Common\Exception\IOException
+     * @throws \OpenSpout\Writer\Exception\WriterNotOpenedException
+     *
+     * @return string
+     */
+    private function createFileWithMiddleEmptyColumnsAndTrailingData()
+    {
+        $file = $this->tempXlsx('middle-empty');
+        $emptyColumns = 5;
+        $styles = array_fill(2, $emptyColumns, (new Style())->setBackgroundColor(Color::YELLOW));
+
+        $writer = new \OpenSpout\Writer\XLSX\Writer();
+        $writer->openToFile($file);
+        $rows = [
+            ['col1', 'col2', '', '', '', '', '', 'extra'],
+            ['row1 col1', 'row1 col2', '', '', '', '', '', 'h1'],
+            ['row2 col1', 'row2 col2', '', '', '', '', '', 'h2'],
+        ];
+        foreach ($rows as $values) {
+            $writer->addRow(\OpenSpout\Common\Entity\Row::fromValuesWithStyles($values, null, $styles));
+        }
+        $writer->close();
+
+        return $file;
+    }
 }

--- a/tests/FastExcelTest.php
+++ b/tests/FastExcelTest.php
@@ -747,6 +747,22 @@ class FastExcelTest extends TestCase
         (new FastExcel())->onlyColumns(['A', 'A']);
     }
 
+    public function testOnlyColumnsRejectsNonIntOrStringMembers()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('onlyColumns() accepts column letters or 1-based indexes.');
+
+        (new FastExcel())->onlyColumns([1.7]);
+    }
+
+    public function testOnlyColumnsRejectsNullMembers()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('onlyColumns() accepts column letters or 1-based indexes.');
+
+        (new FastExcel())->onlyColumns([null]);
+    }
+
     /**
      * Empty headers keep the sheet column number after an allowlist remap.
      *

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,25 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 class TestCase extends BaseTestCase
 {
     /**
+     * Temporary files created during a test; removed in tearDown().
+     *
+     * @var string[]
+     */
+    private $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            if (is_file($file)) {
+                @unlink($file);
+            }
+        }
+        $this->tempFiles = [];
+
+        parent::tearDown();
+    }
+
+    /**
      * @return \Illuminate\Support\Collection
      */
     protected function collection()
@@ -19,5 +38,20 @@ class TestCase extends BaseTestCase
             ['col1' => 'row2 col1', 'col2' => ''],
             ['col1' => 'row3 col1', 'col2' => 'row3 col2'],
         ]);
+    }
+
+    /**
+     * Path under the system temp dir, tracked for automatic cleanup.
+     *
+     * @param string $prefix
+     *
+     * @return string
+     */
+    protected function tempXlsx(string $prefix = 'test'): string
+    {
+        $path = sys_get_temp_dir().'/fastexcel-'.$prefix.'-'.uniqid('', true).'.xlsx';
+        $this->tempFiles[] = $path;
+
+        return $path;
     }
 }


### PR DESCRIPTION
## What

Adds `limitColumns()` and `onlyColumns()` so imports can restrict which columns are kept — the horizontal counterpart to `limitRows()`.

```php
// Truncate after column H (or after 8 columns)
$collection = (new FastExcel)->limitColumns('H')->import('file.xlsx');
$collection = (new FastExcel)->limitColumns(8)->import('file.xlsx');

// Keep only specific columns (letters / 1-based indexes; order preserved)
$collection = (new FastExcel)->onlyColumns(['A', 'B', 'H'])->import('file.xlsx');
$collection = (new FastExcel)->onlyColumns([1, 2, 8])->import('file.xlsx');
```

## Why

Some spreadsheets apply formatting across entire rows. Excel then reports thousands of trailing empty cells as real columns, so every imported row gets empty `column_9`, `column_10`, … keys. `#370` asked for an “end column” style setting to stop that.

`onlyColumns()` covers the related case where useful data sits past a middle band of empties — an allowlist can skip the gap without bringing those cells into the collection.

## Details

- **`limitColumns(int|string|null)`** — stop each row after a column letter (`'H'`, `'AA'`) or 1-based index (`8`). Pass `null` to clear.
- **`onlyColumns(?array)`** — keep only the listed columns (letters and indexes can be mixed); order is preserved. Pass `null` to clear. Rejects an empty list and duplicates.
- The two modes are mutually exclusive: setting one clears the other. Clearing with `null` only unsets that setter and leaves the other alone.
- Filtering runs in `rowValues()` **before** cell values are materialised, so trailing formatted empties never become collection keys. OpenSpout still parses the sheet.
- Honored on both eager (`import` / `importSheet`) and lazy (`importLazy` / `importSheetGenerator`) paths.
- Facade `@method` hints, README examples, and helpers for temp XLSX fixtures (`tempXlsx` + teardown cleanup).

## Tests

Covers:

- trailing formatted empty columns with/without `limitColumns`
- `importLazy` + `limitColumns`
- `onlyColumns` skipping middle empties, order preservation, indexes
- empty header → sheet column number after allowlist remap
- last-call-wins between the two setters; `null` clearing one without wiping the other
- invalid column refs, empty allowlist, duplicates, sparse allowlist keys

Closes #370