### PR TITLE
feat: add rightToLeft() for RTL sheet support via openspout SheetView

### DIFF
--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -223,11 +223,11 @@ trait Exportable
             if ($has_sheets && $last_key !== $key) {
                 $writer->addNewSheetAndMakeItCurrent();
             }
-                if ($this->right_to_left && $writer instanceof Writer) {
-                    $sheetView = new SheetView();
-                    $sheetView->setRightToLeft(true);
-                    $writer->getCurrentSheet()->setSheetView($sheetView);
-                }
+            if ($this->right_to_left && $writer instanceof Writer) {
+                $sheetView = new SheetView();
+                $sheetView->setRightToLeft(true);
+                $writer->getCurrentSheet()->setSheetView($sheetView);
+            }
         }
         $writer->close();
     }

--- a/src/Exportable.php
+++ b/src/Exportable.php
@@ -9,6 +9,8 @@ use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Entity\Style\Style;
 use OpenSpout\Writer\Common\AbstractOptions;
 use OpenSpout\Writer\WriterInterface;
+use OpenSpout\Writer\XLSX\Entity\SheetView;
+use OpenSpout\Writer\XLSX\Writer;
 use Traversable;
 
 /**
@@ -41,6 +43,9 @@ trait Exportable
 
     /** @var string|null */
     private $hidden_column_prefix = null;
+
+    /** @var bool */
+    private $right_to_left = false;
 
     /**
      * @param AbstractOptions $options
@@ -191,6 +196,12 @@ trait Exportable
 
         $writer->$function($path);
 
+        if ($this->right_to_left && $writer instanceof Writer) {
+            $sheetView = new SheetView();
+            $sheetView->setRightToLeft(true);
+            $writer->getCurrentSheet()->setSheetView($sheetView);
+        }
+
         // It can export one sheet (Collection) or N sheets (SheetCollection)
         $data = $this->transpose ? $this->transposeData() : ($this->data instanceof SheetCollection ? $this->data : collect([$this->data]));
 
@@ -212,6 +223,11 @@ trait Exportable
             if ($has_sheets && $last_key !== $key) {
                 $writer->addNewSheetAndMakeItCurrent();
             }
+                if ($this->right_to_left && $writer instanceof Writer) {
+                    $sheetView = new SheetView();
+                    $sheetView->setRightToLeft(true);
+                    $writer->getCurrentSheet()->setSheetView($sheetView);
+                }
         }
         $writer->close();
     }

--- a/src/FastExcel.php
+++ b/src/FastExcel.php
@@ -230,6 +230,13 @@ class FastExcel
         return $this;
     }
 
+    public function rightToLeft(bool $value = true): static
+    {
+        $this->right_to_left = $value;
+
+        return $this;
+    }
+
     /**
      * @param AbstractOptions $options
      */

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -594,10 +594,14 @@ class IssuesTest extends TestCase
         $zip->open($file);
         $sheet1 = $zip->getFromName('xl/worksheets/sheet1.xml');
         $sheet2 = $zip->getFromName('xl/worksheets/sheet2.xml');
+        $sheet3 = $zip->getFromName('xl/worksheets/sheet3.xml');
+        $sheet4 = $zip->getFromName('xl/worksheets/sheet4.xml');
         $zip->close();
 
         $this->assertStringContainsString('rightToLeft="true"', $sheet1);
         $this->assertStringContainsString('rightToLeft="true"', $sheet2);
+        $this->assertStringContainsString('rightToLeft="true"', $sheet3);
+        $this->assertStringContainsString('rightToLeft="true"', $sheet4);
 
         unlink($file);
     }

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -548,7 +548,7 @@ class IssuesTest extends TestCase
     }
 
     /**
-     * Issue #420: exporting a sheet with right-to-left content (e.g. Arabic) 
+     * Issue #420: exporting a sheet with right-to-left content (e.g. Arabic)
      * had no way to set the sheet's reading direction. openspout's
      * SheetView already supports this via setRightToLeft(); rightToLeft()
      * exposes it, applied once the writer is opened (the sheet does not exist

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -5,6 +5,7 @@ namespace Rap2hpoutre\FastExcel\Tests;
 use Illuminate\Support\Collection;
 use Rap2hpoutre\FastExcel\FastExcel;
 use Rap2hpoutre\FastExcel\SheetCollection;
+use ZipArchive;
 
 /**
  * Class IssuesTest.
@@ -545,4 +546,60 @@ class IssuesTest extends TestCase
         $this->assertInstanceOf(Collection::class, $rows);
         $this->assertEquals($this->collection(), $rows);
     }
+
+    /**
+     * Issue #420: exporting a sheet with right-to-left content (e.g. Arabic) 
+     * had no way to set the sheet's reading direction. openspout's
+     * SheetView already supports this via setRightToLeft(); rightToLeft()
+     * exposes it, applied once the writer is opened (the sheet does not exist
+     * yet inside configureWriterUsing()).
+     *
+     * @see https://github.com/rap2hpoutre/fast-excel/issues/420
+     */
+    public function testIssue420()
+    {
+        $file = __DIR__.'/issue420.xlsx';
+
+        (new FastExcel(collect([['name' => 'محمد', 'value' => 100]])))
+            ->rightToLeft()
+            ->export($file);
+
+        $zip = new ZipArchive();
+        $zip->open($file);
+        $sheetXml = $zip->getFromName('xl/worksheets/sheet1.xml');
+        $zip->close();
+
+        $this->assertStringContainsString('rightToLeft="true"', $sheetXml);
+
+        unlink($file);
+    }
+
+    /**
+     * rightToLeft() must apply to every sheet in a SheetCollection export, not
+     * only the first — SheetView has to be re-applied after each
+     * addNewSheetAndMakeItCurrent() call.
+     */
+    public function testIssue420MultiSheet()
+    {
+        $file = __DIR__.'/issue420_multisheet.xlsx';
+
+        (new FastExcel(new SheetCollection([
+            'Sheet A' => collect([['name' => 'محمد']]),
+            'Sheet B' => collect([['name' => 'محمود']]),
+            'Sheet C' => collect([['name' => 'احمد']]),
+            'Sheet D' => collect([['name' => 'عماد']]),
+        ])))->rightToLeft()->export($file);
+
+        $zip = new ZipArchive();
+        $zip->open($file);
+        $sheet1 = $zip->getFromName('xl/worksheets/sheet1.xml');
+        $sheet2 = $zip->getFromName('xl/worksheets/sheet2.xml');
+        $zip->close();
+
+        $this->assertStringContainsString('rightToLeft="true"', $sheet1);
+        $this->assertStringContainsString('rightToLeft="true"', $sheet2);
+
+        unlink($file);
+    }
+
 }

--- a/tests/IssuesTest.php
+++ b/tests/IssuesTest.php
@@ -601,5 +601,4 @@ class IssuesTest extends TestCase
 
         unlink($file);
     }
-
 }


### PR DESCRIPTION
Fixes #420. Adds a `rightToLeft()` method to `FastExcel` for RTL sheet export 
(Arabic/RTL content), using openspout's `SheetView::setRightToLeft()`.